### PR TITLE
DB-1174: delete RPKI objects that are not referenced from manifests

### DIFF
--- a/src/main/java/net/ripe/rpki/validator3/adapter/jpa/JPARpkiObjects.java
+++ b/src/main/java/net/ripe/rpki/validator3/adapter/jpa/JPARpkiObjects.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Repository;
 
 import javax.transaction.Transactional;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -85,6 +86,11 @@ public class JPARpkiObjects extends JPARepository<RpkiObject> implements RpkiObj
             .select(certificateTreeValidationRun, rpkiObject);
         return stream(query)
             .map(x -> Pair.of(x.get(0, CertificateTreeValidationRun.class), x.get(1, RpkiObject.class)));
+    }
+
+    @Override
+    public long deleteUnreachableObjects(Instant unreachableSince) {
+        return queryFactory.delete(rpkiObject).where(rpkiObject.lastMarkedReachableAt.before(unreachableSince)).execute();
     }
 
     @Override

--- a/src/main/java/net/ripe/rpki/validator3/adapter/jpa/JPARpkiObjects.java
+++ b/src/main/java/net/ripe/rpki/validator3/adapter/jpa/JPARpkiObjects.java
@@ -29,17 +29,25 @@
  */
 package net.ripe.rpki.validator3.adapter.jpa;
 
+import com.google.common.primitives.UnsignedBytes;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQuery;
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
 import net.ripe.rpki.validator3.domain.CertificateTreeValidationRun;
 import net.ripe.rpki.validator3.domain.RpkiObject;
 import net.ripe.rpki.validator3.domain.RpkiObjects;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.LockModeType;
 import javax.transaction.Transactional;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static net.ripe.rpki.validator3.domain.querydsl.QCertificateTreeValidationRun.certificateTreeValidationRun;
@@ -56,6 +64,16 @@ public class JPARpkiObjects extends JPARepository<RpkiObject> implements RpkiObj
     @Override
     public Optional<RpkiObject> findBySha256(byte[] sha256) {
         return Optional.ofNullable(select().where(rpkiObject.sha256.eq(sha256)).fetchFirst());
+    }
+
+    @Override
+    public Map<String, RpkiObject> findObjectsInManifest(ManifestCms manifestCms, LockModeType lockMode) {
+        SortedMap<byte[], String> hashes = new TreeMap<>(UnsignedBytes.lexicographicalComparator());
+        manifestCms.getFiles().forEach((name, hash) -> hashes.put(hash, name));
+
+        List<RpkiObject> objects = select().setLockMode(lockMode).where(rpkiObject.sha256.in(hashes.keySet())).fetch();
+
+        return objects.stream().collect(Collectors.toMap(object -> hashes.get(object.getSha256()), object -> object));
     }
 
     @Override

--- a/src/main/java/net/ripe/rpki/validator3/domain/RpkiObject.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/RpkiObject.java
@@ -98,6 +98,11 @@ public class RpkiObject extends AbstractEntity {
     @Getter
     private Instant signingTime;
 
+    @Basic(optional = false)
+    @Getter
+    @NotNull
+    private Instant lastMarkedReachableAt;
+
     @Basic
     @Getter
     private byte[] authorityKeyIdentifier;
@@ -133,6 +138,7 @@ public class RpkiObject extends AbstractEntity {
         this.locations.add(location);
         this.encoded = object.getEncoded();
         this.sha256 = Sha256.hash(this.encoded);
+        this.lastMarkedReachableAt = Instant.now();
         if (object instanceof X509ResourceCertificate) {
             this.serialNumber = ((X509ResourceCertificate) object).getSerialNumber();
             this.signingTime = null; // Use not valid before instead?
@@ -210,6 +216,14 @@ public class RpkiObject extends AbstractEntity {
 
     public void removeLocation(String location) {
         this.locations.remove(location);
+    }
+
+    /**
+     * Mark this object as currently reachable by following a chain of references from the
+     * trust anchors through manifest to this object.
+     */
+    public void markReachable(Instant now) {
+        this.lastMarkedReachableAt = now;
     }
 
     @Override

--- a/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
@@ -1,0 +1,155 @@
+/**
+ * The BSD License
+ * <p>
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ * <p>
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * - Neither the name of the RIPE NCC nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ * <p>
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.rpki.validator3.domain;
+
+import lombok.extern.slf4j.Slf4j;
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
+import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.persistence.EntityManager;
+import javax.persistence.FlushModeType;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class RpkiObjectCleanupService {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private TrustAnchors trustAnchors;
+
+    @Autowired
+    private RpkiObjects rpkiObjects;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    private final Duration cleanupGraceDuration;
+
+    public RpkiObjectCleanupService(@Value("${rpki.validator.rpki.object.cleanup.grace.duration}") String cleanupGraceDuration) {
+        this.cleanupGraceDuration = Duration.parse(cleanupGraceDuration);
+    }
+
+    /**
+     * Marks all RPKI objects that are reachable from a trust anchor by following the entries in the manifests.
+     */
+    @Scheduled(initialDelay = 60_000, fixedDelayString = "${rpki.validator.rpki.object.cleanup.interval.ms}")
+    public long cleanupRpkiObjects() {
+        Instant now = Instant.now();
+        for (TrustAnchor trustAnchor : trustAnchors.findAll()) {
+            transactionTemplate.execute((status) -> {
+                entityManager.clear();
+                entityManager.setFlushMode(FlushModeType.COMMIT);
+
+                log.info("tracing objects for trust anchor {}", trustAnchor);
+
+                X509ResourceCertificate resourceCertificate = trustAnchor.getCertificate();
+                if (resourceCertificate != null) {
+                    traceCertificateAuthority(now, resourceCertificate);
+                }
+
+                return null;
+            });
+        }
+
+        return deleteUnreachableObjects(now);
+    }
+
+    private long deleteUnreachableObjects(Instant now) {
+        return transactionTemplate.execute((status) -> {
+            entityManager.flush();
+
+            Instant unreachableSince = now.minus(cleanupGraceDuration);
+            long count = rpkiObjects.deleteUnreachableObjects(unreachableSince);
+            log.info("Deleted {} RPKI objects that have not been marked reachable since {}", count, unreachableSince);
+            return count;
+        });
+    }
+
+    private void traceCertificateAuthority(Instant now, X509ResourceCertificate resourceCertificate) {
+        if (resourceCertificate == null || resourceCertificate.getManifestUri() == null) {
+            return;
+        }
+
+        Optional<RpkiObject> maybeManifest = rpkiObjects.findLatestByTypeAndAuthorityKeyIdentifier(
+            RpkiObject.Type.MFT,
+            resourceCertificate.getSubjectKeyIdentifier()
+        );
+        maybeManifest.ifPresent(manifest -> {
+            markAndTraceObject(now, "manifest.mft", manifest);
+        });
+    }
+
+    private void markAndTraceObject(Instant now, String name, RpkiObject rpkiObject) {
+        if (now == rpkiObject.getLastMarkedReachableAt()) {
+            log.warn("object already marked, skipping {}", rpkiObject);
+        }
+
+        rpkiObject.markReachable(now);
+        switch (rpkiObject.getType()) {
+            case MFT:
+                traceManifest(now, name, rpkiObject);
+                break;
+            case CER:
+                traceCaCertificate(now, name, rpkiObject);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void traceManifest(Instant now, String name, RpkiObject manifest) {
+        manifest.get(ManifestCms.class, name).ifPresent(manifestCms -> {
+            manifestCms.getFiles().forEach((entry, sha256) -> {
+                rpkiObjects.findBySha256(sha256).ifPresent(rpkiObject -> {
+                    markAndTraceObject(now, entry, rpkiObject);
+                });
+            });
+        });
+    }
+
+    private void traceCaCertificate(Instant now, String name, RpkiObject caCertificate) {
+        caCertificate.get(X509ResourceCertificate.class, name).ifPresent(certificate -> {
+            if (certificate.isCa() && certificate.getManifestUri() != null) {
+                traceCertificateAuthority(now, certificate);
+            }
+        });
+    }
+
+}

--- a/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
@@ -40,6 +40,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import javax.persistence.EntityManager;
 import javax.persistence.FlushModeType;
+import javax.persistence.LockModeType;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
@@ -136,10 +137,8 @@ public class RpkiObjectCleanupService {
 
     private void traceManifest(Instant now, String name, RpkiObject manifest) {
         manifest.get(ManifestCms.class, name).ifPresent(manifestCms -> {
-            manifestCms.getFiles().forEach((entry, sha256) -> {
-                rpkiObjects.findBySha256(sha256).ifPresent(rpkiObject -> {
-                    markAndTraceObject(now, entry, rpkiObject);
-                });
+            rpkiObjects.findObjectsInManifest(manifestCms, LockModeType.PESSIMISTIC_WRITE).forEach((entry, rpkiObject) -> {
+                markAndTraceObject(now, entry, rpkiObject);
             });
         });
     }

--- a/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
@@ -68,6 +68,7 @@ public class RpkiObjectCleanupService {
 
     /**
      * Marks all RPKI objects that are reachable from a trust anchor by following the entries in the manifests.
+     * Objects that are no longer reachable will be deleted after a configurable grace duration.
      */
     @Scheduled(initialDelay = 60_000, fixedDelayString = "${rpki.validator.rpki.object.cleanup.interval.ms}")
     public long cleanupRpkiObjects() {

--- a/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
@@ -118,8 +118,10 @@ public class RpkiObjectCleanupService {
     }
 
     private void markAndTraceObject(Instant now, String name, RpkiObject rpkiObject) {
+        // Compare object instance identity to see if we've already visited
+        // the `rpkiObject` in the current run.
         if (now == rpkiObject.getLastMarkedReachableAt()) {
-            log.warn("object already marked, skipping {}", rpkiObject);
+            log.debug("object already marked, skipping {}", rpkiObject);
         }
 
         rpkiObject.markReachable(now);

--- a/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupService.java
@@ -1,20 +1,20 @@
 /**
  * The BSD License
- * <p>
+ *
  * Copyright (c) 2010-2018 RIPE NCC
  * All rights reserved.
- * <p>
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * - Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice,
- * this list of conditions and the following disclaimer in the documentation
- * and/or other materials provided with the distribution.
- * - Neither the name of the RIPE NCC nor the names of its contributors may be
- * used to endorse or promote products derived from this software without
- * specific prior written permission.
- * <p>
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -75,7 +75,6 @@ public class RpkiObjectCleanupService {
         Instant now = Instant.now();
         for (TrustAnchor trustAnchor : trustAnchors.findAll()) {
             transactionTemplate.execute((status) -> {
-                entityManager.clear();
                 entityManager.setFlushMode(FlushModeType.COMMIT);
 
                 log.info("tracing objects for trust anchor {}", trustAnchor);

--- a/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjects.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjects.java
@@ -31,7 +31,7 @@ package net.ripe.rpki.validator3.domain;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import java.util.List;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -53,4 +53,6 @@ public interface RpkiObjects {
     Optional<RpkiObject> findLatestByTypeAndAuthorityKeyIdentifier(RpkiObject.Type type, byte[] authorityKeyIdentifier);
 
     Stream<Pair<CertificateTreeValidationRun, RpkiObject>> findCurrentlyValidated(RpkiObject.Type type);
+
+    long deleteUnreachableObjects(Instant unreachableSince);
 }

--- a/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjects.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjects.java
@@ -29,9 +29,12 @@
  */
 package net.ripe.rpki.validator3.domain;
 
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
 import org.apache.commons.lang3.tuple.Pair;
 
+import javax.persistence.LockModeType;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -47,6 +50,8 @@ public interface RpkiObjects {
     RpkiObject get(long id);
 
     Optional<RpkiObject> findBySha256(byte[] sha256);
+
+    Map<String, RpkiObject> findObjectsInManifest(ManifestCms manifestCms, LockModeType lockMode);
 
     Stream<RpkiObject> all();
 

--- a/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
+++ b/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
@@ -86,7 +86,7 @@ public class RpkiRepositoryValidationService {
     private final RpkiObjects rpkiObjects;
     private final RrdpService rrdpService;
     private final File rsyncLocalStorageDirectory;
-    private final String rsyncRepositoryDownloadInterval;
+    private final Duration rsyncRepositoryDownloadInterval;
 
     @Autowired
     public RpkiRepositoryValidationService(
@@ -103,7 +103,7 @@ public class RpkiRepositoryValidationService {
         this.rpkiObjects = rpkiObjects;
         this.rrdpService = rrdpService;
         this.rsyncLocalStorageDirectory = rsyncLocalStorageDirectory;
-        this.rsyncRepositoryDownloadInterval = rsyncRepositoryDownloadInterval;
+        this.rsyncRepositoryDownloadInterval = Duration.parse(rsyncRepositoryDownloadInterval);
     }
 
     public void validateRpkiRepository(long rpkiRepositoryId) {
@@ -146,7 +146,7 @@ public class RpkiRepositoryValidationService {
     public void validateRsyncRepositories() {
         entityManager.setFlushMode(FlushModeType.COMMIT);
 
-        Instant cutoffTime = Instant.now().minus(Duration.parse(rsyncRepositoryDownloadInterval));
+        Instant cutoffTime = Instant.now().minus(rsyncRepositoryDownloadInterval);
         log.info("updating all rsync repositories that have not been downloaded since {}", cutoffTime);
 
         Set<TrustAnchor> affectedTrustAnchors = new HashSet<>();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,4 +59,7 @@ rpki.validator.rsync.repository.download.interval=PT10M
 
 rpki.validator.rrdp.trust.all.tls.certificates=true
 
+rpki.validator.rpki.object.cleanup.interval.ms=3600000
+rpki.validator.rpki.object.cleanup.grace.duration=P7D
+
 spring.jackson.date-format=yyyy-MM-dd hh:mm:ss

--- a/src/main/resources/db/migration/V3__domain.sql
+++ b/src/main/resources/db/migration/V3__domain.sql
@@ -96,6 +96,7 @@ CREATE TABLE rpki_object (
     type VARCHAR NOT NULL,
     serial_number DECIMAL(1000, 0),
     signing_time TIMESTAMP,
+    last_marked_reachable_at TIMESTAMP NOT NULL,
     authority_key_identifier BINARY(32),
     sha256 BINARY(32) NOT NULL,
     encoded BINARY,

--- a/src/test/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupServiceTest.java
+++ b/src/test/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupServiceTest.java
@@ -1,0 +1,68 @@
+package net.ripe.rpki.validator3.domain;
+
+import net.ripe.ipresource.Asn;
+import net.ripe.ipresource.IpRange;
+import net.ripe.ipresource.IpResourceSet;
+import net.ripe.rpki.commons.crypto.ValidityPeriod;
+import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificateBuilder;
+import net.ripe.rpki.validator3.IntegrationTest;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.persistence.EntityManager;
+import javax.security.auth.x500.X500Principal;
+import javax.transaction.Transactional;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+
+import static net.ripe.rpki.validator3.domain.TrustAnchorsFactory.KEY_PAIR_FACTORY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@IntegrationTest
+@Transactional
+public class RpkiObjectCleanupServiceTest {
+
+    @Autowired
+    private TrustAnchorsFactory factory;
+
+    @Autowired
+    private RpkiObjectCleanupService subject;
+
+    @Autowired
+    private RpkiObjects rpkiObjects;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    public void should_delete_objects_not_reachable_from_manifest() {
+        TrustAnchor trustAnchor = factory.createTrustAnchor(ta -> {
+            ta.roaPrefixes(Arrays.asList(RoaPrefix.of(IpRange.parse("127.0.0.0/8"), null, Asn.parse("123"))));
+        });
+
+        RpkiObject orphan = new RpkiObject(
+            "rsync://localhost/orphan.cer",
+            new X509ResourceCertificateBuilder()
+                .withResources(IpResourceSet.parse("10.0.0.0/8"))
+                .withIssuerDN(trustAnchor.getCertificate().getSubject())
+                .withSubjectDN(new X500Principal("CN=orphan"))
+                .withSerial(factory.nextSerial())
+                .withPublicKey(KEY_PAIR_FACTORY.generate().getPublic())
+                .withSigningKeyPair(KEY_PAIR_FACTORY.generate())
+                .withValidityPeriod(new ValidityPeriod(DateTime.now(), DateTime.now().plusYears(1)))
+                .build()
+        );
+        orphan.markReachable(Instant.now().minus(Duration.ofDays(10)));
+        rpkiObjects.add(orphan);
+        entityManager.flush();
+
+        long deletedCount = subject.cleanupRpkiObjects();
+
+        assertThat(deletedCount).isEqualTo(1);
+    }
+}

--- a/src/test/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupServiceTest.java
+++ b/src/test/java/net/ripe/rpki/validator3/domain/RpkiObjectCleanupServiceTest.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.domain;
 
 import net.ripe.ipresource.Asn;

--- a/src/test/java/net/ripe/rpki/validator3/domain/TrustAnchorsFactory.java
+++ b/src/test/java/net/ripe/rpki/validator3/domain/TrustAnchorsFactory.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.domain;
 
 import com.google.common.io.Resources;

--- a/src/test/java/net/ripe/rpki/validator3/domain/TrustAnchorsFactory.java
+++ b/src/test/java/net/ripe/rpki/validator3/domain/TrustAnchorsFactory.java
@@ -1,0 +1,238 @@
+package net.ripe.rpki.validator3.domain;
+
+import com.google.common.io.Resources;
+import lombok.Builder;
+import lombok.Value;
+import net.ripe.ipresource.Asn;
+import net.ripe.ipresource.IpRange;
+import net.ripe.ipresource.IpResourceSet;
+import net.ripe.ipresource.IpResourceType;
+import net.ripe.rpki.commons.crypto.ValidityPeriod;
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
+import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCmsBuilder;
+import net.ripe.rpki.commons.crypto.cms.roa.RoaCms;
+import net.ripe.rpki.commons.crypto.cms.roa.RoaCmsBuilder;
+import net.ripe.rpki.commons.crypto.crl.X509Crl;
+import net.ripe.rpki.commons.crypto.crl.X509CrlBuilder;
+import net.ripe.rpki.commons.crypto.util.CertificateRepositoryObjectFactory;
+import net.ripe.rpki.commons.crypto.util.KeyPairFactory;
+import net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor;
+import net.ripe.rpki.commons.crypto.x509cert.X509CertificateUtil;
+import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificate;
+import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificateBuilder;
+import net.ripe.rpki.commons.validation.ValidationResult;
+import net.ripe.rpki.validator3.domain.validation.CertificateTreeValidationServiceTest;
+import net.ripe.rpki.validator3.domain.validation.TrustAnchorValidationServiceTest;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.security.auth.x500.X500Principal;
+import javax.transaction.Transactional;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+
+@Component
+@Transactional
+public class TrustAnchorsFactory {
+    private static final X509ResourceCertificate RIPE_NCC_TA_CERTIFICATE = loadCertificate("/ripe-ncc-ta.cer");
+    public static final String TA_RRDP_NOTIFY_URI = "https://rpki.test/notification.xml";
+    public static final String TA_CA_REPOSITORY_URI = "rsync://rpki.test/repository";
+    private static final String TA_MANIFEST_URI = "rsync://rpki.test/test-trust-anchor.mft";
+    private static final String TA_CRL_URI = "rsync://rpki.test/test-trust-anchor.crl";
+    public static final KeyPairFactory KEY_PAIR_FACTORY = new KeyPairFactory(BouncyCastleProvider.PROVIDER_NAME);
+    private static final String TA_ISSUER_DN = "CN=test";
+
+    private static X509ResourceCertificate loadCertificate(String name) {
+        try {
+            byte[] encoded = Resources.toByteArray(CertificateTreeValidationServiceTest.class.getResource(name));
+            return (X509ResourceCertificate) CertificateRepositoryObjectFactory.createCertificateRepositoryObject(encoded, ValidationResult.withLocation(name));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Autowired
+    private RpkiObjects rpkiObjects;
+
+    private static BigInteger nextSerial = BigInteger.ONE;
+
+    @PostConstruct
+    public void add_security_provider() {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+
+    public TrustAnchor createTrustAnchor(Consumer<CertificateAuthority.CertificateAuthorityBuilder> configure) {
+        KeyPair rootKeyPair = KEY_PAIR_FACTORY.generate();
+        CertificateAuthority.CertificateAuthorityBuilder builder = CertificateAuthority.builder()
+            .dn("CN=test-trust-anchor")
+            .keyPair(rootKeyPair)
+            .certificateLocation("rsync://rpki.test/test-trust-anchor.cer")
+            .resources(IpResourceSet.parse("0.0.0.0/0"))
+            .notifyURI(TA_RRDP_NOTIFY_URI)
+            .manifestURI(TA_MANIFEST_URI)
+            .repositoryURI(TA_CA_REPOSITORY_URI)
+            .crlDistributionPoint(TA_CRL_URI);
+        configure.accept(builder);
+        CertificateAuthority root = builder.build();
+
+        X509ResourceCertificate certificate = createCertificateAuthority(root, root);
+
+        TrustAnchor ta = new TrustAnchor();
+        ta.setName(root.dn);
+        ta.getLocations().add(root.certificateLocation);
+        ta.setCertificate(certificate);
+        ta.setSubjectPublicKeyInfo(X509CertificateUtil.getEncodedSubjectPublicKeyInfo(certificate.getCertificate()));
+        return ta;
+    }
+
+    public X509ResourceCertificate createCertificateAuthority(CertificateAuthority ca, CertificateAuthority issuer) {
+        ManifestCmsBuilder manifestBuilder = new ManifestCmsBuilder();
+
+        X509ResourceCertificate caCertificate = createCaCertificate(ca, ca.keyPair.getPublic(), issuer.dn, issuer.crlDistributionPoint, issuer.keyPair);
+
+        X509Crl crl = new X509CrlBuilder()
+            .withIssuerDN(caCertificate.getSubject())
+            .withThisUpdateTime(DateTime.now())
+            .withNextUpdateTime(DateTime.now().plusHours(8))
+            .withAuthorityKeyIdentifier(ca.keyPair.getPublic())
+            .withNumber(nextSerial())
+            .build(ca.keyPair.getPrivate());
+
+        rpkiObjects.add(new RpkiObject(ca.crlDistributionPoint, crl));
+        manifestBuilder.addFile(ca.crlDistributionPoint.substring(ca.crlDistributionPoint.lastIndexOf('/') + 1), crl.getEncoded());
+
+        if (ca.children != null) {
+            for (CertificateAuthority child : ca.children) {
+                X509ResourceCertificate childCertificate = createCertificateAuthority(child, ca);
+
+                rpkiObjects.add(new RpkiObject(ca.repositoryURI + "/" + child.dn + ".cer", childCertificate));
+                manifestBuilder.addFile(child.dn + ".cer", childCertificate.getEncoded());
+            }
+        }
+
+        if (ca.roaPrefixes != null) {
+            ca.roaPrefixes.stream().collect(groupingBy(RoaPrefix::getAsn)).forEach((asn, roaPrefix) -> {
+                KeyPair roaKeyPair = KEY_PAIR_FACTORY.generate();
+                IpResourceSet resources = new IpResourceSet();
+                roaPrefix.stream().forEach(p -> resources.add(IpRange.parse(p.getPrefix())));
+                X509ResourceCertificate roaCertificate = new X509ResourceCertificateBuilder()
+//                    .withInheritedResourceTypes(EnumSet.allOf(IpResourceType.class))
+                    .withResources(resources)
+                    .withIssuerDN(new X500Principal(ca.dn))
+                    .withSubjectDN(new X500Principal("CN=AS" + asn + ", CN=roa, " + ca.dn))
+                    .withValidityPeriod(new ValidityPeriod(org.joda.time.Instant.now(), org.joda.time.Instant.now().plus(Duration.standardDays(1))))
+                    .withPublicKey(roaKeyPair.getPublic())
+                    .withSigningKeyPair(ca.keyPair)
+                    .withCa(false)
+                    .withKeyUsage(KeyUsage.digitalSignature)
+                    .withSerial(nextSerial())
+                    .withCrlDistributionPoints(URI.create(ca.crlDistributionPoint))
+                    .build();
+                RoaCms roaCms = new RoaCmsBuilder()
+                    .withAsn(new Asn(asn))
+                    .withPrefixes(roaPrefix.stream()
+                        .map(p -> new net.ripe.rpki.commons.crypto.cms.roa.RoaPrefix(IpRange.parse(p.getPrefix()), p.getMaximumLength()))
+                        .collect(toList()))
+                    .withCertificate(roaCertificate)
+                    .withSignatureProvider(BouncyCastleProvider.PROVIDER_NAME)
+                    .build(roaKeyPair.getPrivate());
+
+                rpkiObjects.add(new RpkiObject(ca.repositoryURI + "/" + "AS" + asn + ".roa", roaCms));
+                manifestBuilder.addFile("AS" + asn + ".roa", roaCms.getEncoded());
+            });
+        }
+
+        KeyPair manifestKeyPair = KEY_PAIR_FACTORY.generate();
+        X509ResourceCertificate manifestCertificate = new X509ResourceCertificateBuilder()
+            .withInheritedResourceTypes(EnumSet.allOf(IpResourceType.class))
+            .withIssuerDN(caCertificate.getSubject())
+            .withSubjectDN(new X500Principal("CN=manifest, " + caCertificate.getSubject()))
+            .withValidityPeriod(new ValidityPeriod(org.joda.time.Instant.now(), org.joda.time.Instant.now().plus(Duration.standardDays(1))))
+            .withPublicKey(manifestKeyPair.getPublic())
+            .withSigningKeyPair(ca.keyPair)
+            .withCa(false)
+            .withKeyUsage(KeyUsage.digitalSignature)
+            .withSerial(nextSerial())
+            .withCrlDistributionPoints(URI.create(ca.crlDistributionPoint))
+            .build();
+        manifestBuilder
+            .withCertificate(manifestCertificate)
+            .withManifestNumber(nextSerial())
+            .withThisUpdateTime(DateTime.now())
+            .withNextUpdateTime(DateTime.now().plusHours(8));
+        ManifestCms manifest = manifestBuilder.build(manifestKeyPair.getPrivate());
+        rpkiObjects.add(new RpkiObject(ca.manifestURI, manifest));
+        return caCertificate;
+    }
+
+    public X509ResourceCertificate createCaCertificate(CertificateAuthority ca, PublicKey publicKey, String issuerDN, String crlDistributionPoint, KeyPair signingKey) {
+        List<X509CertificateInformationAccessDescriptor> sia = new ArrayList<>();
+        sia.add(new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_RPKI_MANIFEST, URI.create(ca.manifestURI)));
+        sia.add(new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_CA_REPOSITORY, URI.create(ca.repositoryURI)));
+        if (ca.notifyURI != null) {
+            sia.add(new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_RPKI_NOTIFY, URI.create(ca.notifyURI)));
+        }
+
+        return new X509ResourceCertificateBuilder()
+            .withResources(ca.resources)
+            .withIssuerDN(new X500Principal(issuerDN))
+            .withSubjectDN(new X500Principal(ca.dn))
+            .withSubjectInformationAccess(sia.toArray(new X509CertificateInformationAccessDescriptor[0]))
+            .withCrlDistributionPoints(URI.create(crlDistributionPoint))
+            .withCa(true)
+            .withKeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign)
+            .withSerial(nextSerial())
+            .withValidityPeriod(new ValidityPeriod(Instant.now(), Instant.now().plus(Duration.standardDays(7))))
+            .withSubjectKeyIdentifier(true)
+            .withPublicKey(publicKey)
+            .withSigningKeyPair(signingKey)
+            .build();
+    }
+
+    public TrustAnchor createRipeNccTrustAnchor() {
+        TrustAnchor ta = TrustAnchorValidationServiceTest.createRipeNccTrustAnchor();
+        ta.setCertificate(RIPE_NCC_TA_CERTIFICATE);
+        return ta;
+    }
+
+    public static BigInteger nextSerial() {
+        BigInteger result = nextSerial;
+        nextSerial = nextSerial.add(BigInteger.ONE);
+        return result;
+    }
+
+    @Value
+    @Builder
+    public static class CertificateAuthority {
+        String dn;
+        KeyPair keyPair;
+        String certificateLocation;
+        IpResourceSet resources;
+        String notifyURI;
+        String manifestURI;
+        String repositoryURI;
+
+        String crlDistributionPoint;
+
+        List<CertificateAuthority> children;
+        List<RoaPrefix> roaPrefixes;
+    }
+}

--- a/src/test/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationServiceTest.java
+++ b/src/test/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationServiceTest.java
@@ -29,27 +29,11 @@
  */
 package net.ripe.rpki.validator3.domain.validation;
 
-import com.google.common.io.Resources;
-import lombok.Builder;
-import lombok.Value;
 import net.ripe.ipresource.Asn;
 import net.ripe.ipresource.IpAddress;
 import net.ripe.ipresource.IpRange;
 import net.ripe.ipresource.IpResourceSet;
-import net.ripe.ipresource.IpResourceType;
-import net.ripe.rpki.commons.crypto.ValidityPeriod;
-import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
-import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCmsBuilder;
-import net.ripe.rpki.commons.crypto.cms.roa.RoaCms;
-import net.ripe.rpki.commons.crypto.cms.roa.RoaCmsBuilder;
-import net.ripe.rpki.commons.crypto.crl.X509Crl;
-import net.ripe.rpki.commons.crypto.crl.X509CrlBuilder;
-import net.ripe.rpki.commons.crypto.util.CertificateRepositoryObjectFactory;
-import net.ripe.rpki.commons.crypto.util.KeyPairFactory;
-import net.ripe.rpki.commons.crypto.x509cert.X509CertificateInformationAccessDescriptor;
-import net.ripe.rpki.commons.crypto.x509cert.X509CertificateUtil;
 import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificate;
-import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificateBuilder;
 import net.ripe.rpki.commons.validation.ValidationResult;
 import net.ripe.rpki.validator3.IntegrationTest;
 import net.ripe.rpki.validator3.domain.CertificateTreeValidationRun;
@@ -60,13 +44,10 @@ import net.ripe.rpki.validator3.domain.RpkiRepositories;
 import net.ripe.rpki.validator3.domain.RpkiRepository;
 import net.ripe.rpki.validator3.domain.TrustAnchor;
 import net.ripe.rpki.validator3.domain.TrustAnchors;
+import net.ripe.rpki.validator3.domain.TrustAnchorsFactory;
 import net.ripe.rpki.validator3.domain.ValidationRuns;
 import org.apache.commons.lang3.tuple.Pair;
-import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.joda.time.DateTime;
-import org.joda.time.Duration;
-import org.joda.time.Instant;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -76,20 +57,15 @@ import org.springframework.test.context.junit4.SpringRunner;
 import javax.persistence.EntityManager;
 import javax.security.auth.x500.X500Principal;
 import javax.transaction.Transactional;
-import java.io.IOException;
-import java.math.BigInteger;
-import java.net.URI;
 import java.security.KeyPair;
-import java.security.PublicKey;
 import java.security.Security;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.function.Consumer;
 
-import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
+import static net.ripe.rpki.validator3.domain.TrustAnchorsFactory.KEY_PAIR_FACTORY;
+import static net.ripe.rpki.validator3.domain.TrustAnchorsFactory.TA_CA_REPOSITORY_URI;
+import static net.ripe.rpki.validator3.domain.TrustAnchorsFactory.TA_RRDP_NOTIFY_URI;
 import static net.ripe.rpki.validator3.domain.ValidationRun.Status.SUCCEEDED;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -98,24 +74,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 public class CertificateTreeValidationServiceTest {
 
-    private static final X509ResourceCertificate RIPE_NCC_TA_CERTIFICATE = loadCertificate("/ripe-ncc-ta.cer");
-    private static final String TA_RRDP_NOTIFY_URI = "https://rpki.test/notification.xml";
-    private static final String TA_CA_REPOSITORY_URI = "rsync://rpki.test/repository";
-    private static final String TA_MANIFEST_URI = "rsync://rpki.test/test-trust-anchor.mft";
-    private static final String TA_CRL_URI = "rsync://rpki.test/test-trust-anchor.crl";
-    private static final KeyPairFactory KEY_PAIR_FACTORY = new KeyPairFactory(BouncyCastleProvider.PROVIDER_NAME);
-    private static final String TA_ISSUER_DN = "CN=test";
-
-    private static X509ResourceCertificate loadCertificate(String name) {
-        try {
-            byte[] encoded = Resources.toByteArray(CertificateTreeValidationServiceTest.class.getResource(name));
-            return (X509ResourceCertificate) CertificateRepositoryObjectFactory.createCertificateRepositoryObject(encoded, ValidationResult.withLocation(name));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static BigInteger nextSerial = BigInteger.ONE;
+    @Autowired
+    private TrustAnchorsFactory factory;
 
     @Autowired
     private EntityManager entityManager;
@@ -135,14 +95,9 @@ public class CertificateTreeValidationServiceTest {
     @Autowired
     private RpkiObjects rpkiObjects;
 
-    @BeforeClass
-    public static void add_security_provider() {
-        Security.addProvider(new BouncyCastleProvider());
-    }
-
     @Test
     public void should_register_rpki_repositories() {
-        TrustAnchor ta = createRipeNccTrustAnchor();
+        TrustAnchor ta = factory.createRipeNccTrustAnchor();
         trustAnchors.add(ta);
 
         subject.validate(ta.getId());
@@ -165,7 +120,7 @@ public class CertificateTreeValidationServiceTest {
 
     @Test
     public void should_register_rsync_repositories() {
-        TrustAnchor ta = createTrustAnchor(x -> {
+        TrustAnchor ta = factory.createTrustAnchor(x -> {
             x.notifyURI(null);
             x.repositoryURI(TA_CA_REPOSITORY_URI);
         });
@@ -192,7 +147,7 @@ public class CertificateTreeValidationServiceTest {
 
     @Test
     public void should_validate_minimal_trust_anchor() {
-        TrustAnchor ta = createTrustAnchor(x -> {
+        TrustAnchor ta = factory.createTrustAnchor(x -> {
         });
         trustAnchors.add(ta);
         RpkiRepository repository = rpkiRepositories.register(ta, TA_RRDP_NOTIFY_URI, RpkiRepository.Type.RRDP);
@@ -220,8 +175,8 @@ public class CertificateTreeValidationServiceTest {
     public void should_validate_child_ca() {
         KeyPair childKeyPair = KEY_PAIR_FACTORY.generate();
 
-        TrustAnchor ta = createTrustAnchor(x -> {
-            CertificateAuthority child = CertificateAuthority.builder()
+        TrustAnchor ta = factory.createTrustAnchor(x -> {
+            TrustAnchorsFactory.CertificateAuthority child = TrustAnchorsFactory.CertificateAuthority.builder()
                 .dn("CN=child-ca")
                 .keyPair(childKeyPair)
                 .certificateLocation("rsync://rpki.test/CN=child-ca.cer")
@@ -252,7 +207,7 @@ public class CertificateTreeValidationServiceTest {
 
     @Test
     public void should_validate_roa() {
-        TrustAnchor ta = createTrustAnchor(x -> {
+        TrustAnchor ta = factory.createTrustAnchor(x -> {
             x.roaPrefixes(Arrays.asList(
                 RoaPrefix.of(IpRange.prefix(IpAddress.parse("192.168.0.0"), 16), 24, Asn.parse("64512"))
             ));
@@ -276,160 +231,4 @@ public class CertificateTreeValidationServiceTest {
         assertThat(validatedRoas.get(0).getRight().getRoaPrefixes()).hasSize(1);
     }
 
-    private TrustAnchor createTrustAnchor(Consumer<CertificateAuthority.CertificateAuthorityBuilder> configure) {
-        KeyPair rootKeyPair = KEY_PAIR_FACTORY.generate();
-        CertificateAuthority.CertificateAuthorityBuilder builder = CertificateAuthority.builder()
-            .dn("CN=test-trust-anchor")
-            .keyPair(rootKeyPair)
-            .certificateLocation("rsync://rpki.test/test-trust-anchor.cer")
-            .resources(IpResourceSet.parse("0.0.0.0/0"))
-            .notifyURI(TA_RRDP_NOTIFY_URI)
-            .manifestURI(TA_MANIFEST_URI)
-            .repositoryURI(TA_CA_REPOSITORY_URI)
-            .crlDistributionPoint(TA_CRL_URI);
-        configure.accept(builder);
-        CertificateAuthority root = builder.build();
-
-        X509ResourceCertificate certificate = createCertificateAuthority(root, root);
-
-        TrustAnchor ta = new TrustAnchor();
-        ta.setName(root.dn);
-        ta.getLocations().add(root.certificateLocation);
-        ta.setCertificate(certificate);
-        ta.setSubjectPublicKeyInfo(X509CertificateUtil.getEncodedSubjectPublicKeyInfo(certificate.getCertificate()));
-        return ta;
-    }
-
-    private X509ResourceCertificate createCertificateAuthority(CertificateAuthority ca, CertificateAuthority issuer) {
-        ManifestCmsBuilder manifestBuilder = new ManifestCmsBuilder();
-
-        X509ResourceCertificate caCertificate = createCaCertificate(ca, ca.keyPair.getPublic(), issuer.dn, issuer.crlDistributionPoint, issuer.keyPair);
-
-        X509Crl crl = new X509CrlBuilder()
-            .withIssuerDN(caCertificate.getSubject())
-            .withThisUpdateTime(DateTime.now())
-            .withNextUpdateTime(DateTime.now().plusHours(8))
-            .withAuthorityKeyIdentifier(ca.keyPair.getPublic())
-            .withNumber(nextSerial())
-            .build(ca.keyPair.getPrivate());
-
-        rpkiObjects.add(new RpkiObject(ca.crlDistributionPoint, crl));
-        manifestBuilder.addFile(ca.crlDistributionPoint.substring(ca.crlDistributionPoint.lastIndexOf('/') + 1), crl.getEncoded());
-
-        if (ca.children != null) {
-            for (CertificateAuthority child : ca.children) {
-                X509ResourceCertificate childCertificate = createCertificateAuthority(child, ca);
-
-                rpkiObjects.add(new RpkiObject(ca.repositoryURI + "/" + child.dn + ".cer", childCertificate));
-                manifestBuilder.addFile(child.dn + ".cer", childCertificate.getEncoded());
-            }
-        }
-
-        if (ca.roaPrefixes != null) {
-            ca.roaPrefixes.stream().collect(groupingBy(RoaPrefix::getAsn)).forEach((asn, roaPrefix) -> {
-                KeyPair roaKeyPair = KEY_PAIR_FACTORY.generate();
-                IpResourceSet resources = new IpResourceSet();
-                roaPrefix.stream().forEach(p -> resources.add(IpRange.parse(p.getPrefix())));
-                X509ResourceCertificate roaCertificate = new X509ResourceCertificateBuilder()
-//                    .withInheritedResourceTypes(EnumSet.allOf(IpResourceType.class))
-                    .withResources(resources)
-                    .withIssuerDN(new X500Principal(ca.dn))
-                    .withSubjectDN(new X500Principal("CN=AS" + asn + ", CN=roa, " + ca.dn))
-                    .withValidityPeriod(new ValidityPeriod(Instant.now(), Instant.now().plus(Duration.standardDays(1))))
-                    .withPublicKey(roaKeyPair.getPublic())
-                    .withSigningKeyPair(ca.keyPair)
-                    .withCa(false)
-                    .withKeyUsage(KeyUsage.digitalSignature)
-                    .withSerial(nextSerial())
-                    .withCrlDistributionPoints(URI.create(ca.crlDistributionPoint))
-                    .build();
-                RoaCms roaCms = new RoaCmsBuilder()
-                    .withAsn(new Asn(asn))
-                    .withPrefixes(roaPrefix.stream()
-                        .map(p -> new net.ripe.rpki.commons.crypto.cms.roa.RoaPrefix(IpRange.parse(p.getPrefix()), p.getMaximumLength()))
-                        .collect(toList()))
-                    .withCertificate(roaCertificate)
-                    .withSignatureProvider(BouncyCastleProvider.PROVIDER_NAME)
-                    .build(roaKeyPair.getPrivate());
-
-                rpkiObjects.add(new RpkiObject(ca.repositoryURI + "/" + "AS" + asn + ".roa", roaCms));
-                manifestBuilder.addFile("AS" + asn + ".roa", roaCms.getEncoded());
-            });
-        }
-
-        KeyPair manifestKeyPair = KEY_PAIR_FACTORY.generate();
-        X509ResourceCertificate manifestCertificate = new X509ResourceCertificateBuilder()
-            .withInheritedResourceTypes(EnumSet.allOf(IpResourceType.class))
-            .withIssuerDN(caCertificate.getSubject())
-            .withSubjectDN(new X500Principal("CN=manifest, " + caCertificate.getSubject()))
-            .withValidityPeriod(new ValidityPeriod(Instant.now(), Instant.now().plus(Duration.standardDays(1))))
-            .withPublicKey(manifestKeyPair.getPublic())
-            .withSigningKeyPair(ca.keyPair)
-            .withCa(false)
-            .withKeyUsage(KeyUsage.digitalSignature)
-            .withSerial(nextSerial())
-            .withCrlDistributionPoints(URI.create(ca.crlDistributionPoint))
-            .build();
-        manifestBuilder
-            .withCertificate(manifestCertificate)
-            .withManifestNumber(nextSerial())
-            .withThisUpdateTime(DateTime.now())
-            .withNextUpdateTime(DateTime.now().plusHours(8));
-        ManifestCms manifest = manifestBuilder.build(manifestKeyPair.getPrivate());
-        rpkiObjects.add(new RpkiObject(ca.manifestURI, manifest));
-        return caCertificate;
-    }
-
-    private X509ResourceCertificate createCaCertificate(CertificateAuthority ca, PublicKey publicKey, String issuerDN, String crlDistributionPoint, KeyPair signingKey) {
-        List<X509CertificateInformationAccessDescriptor> sia = new ArrayList<>();
-        sia.add(new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_RPKI_MANIFEST, URI.create(ca.manifestURI)));
-        sia.add(new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_CA_REPOSITORY, URI.create(ca.repositoryURI)));
-        if (ca.notifyURI != null) {
-            sia.add(new X509CertificateInformationAccessDescriptor(X509CertificateInformationAccessDescriptor.ID_AD_RPKI_NOTIFY, URI.create(ca.notifyURI)));
-        }
-
-        return new X509ResourceCertificateBuilder()
-            .withResources(ca.resources)
-            .withIssuerDN(new X500Principal(issuerDN))
-            .withSubjectDN(new X500Principal(ca.dn))
-            .withSubjectInformationAccess(sia.toArray(new X509CertificateInformationAccessDescriptor[0]))
-            .withCrlDistributionPoints(URI.create(crlDistributionPoint))
-            .withCa(true)
-            .withKeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign)
-            .withSerial(nextSerial())
-            .withValidityPeriod(new ValidityPeriod(Instant.now(), Instant.now().plus(Duration.standardDays(7))))
-            .withSubjectKeyIdentifier(true)
-            .withPublicKey(publicKey)
-            .withSigningKeyPair(signingKey)
-            .build();
-    }
-
-    protected TrustAnchor createRipeNccTrustAnchor() {
-        TrustAnchor ta = TrustAnchorValidationServiceTest.createRipeNccTrustAnchor();
-        ta.setCertificate(RIPE_NCC_TA_CERTIFICATE);
-        return ta;
-    }
-
-    private static BigInteger nextSerial() {
-        BigInteger result = nextSerial;
-        nextSerial = nextSerial.add(BigInteger.ONE);
-        return result;
-    }
-
-    @Value
-    @Builder
-    public static class CertificateAuthority {
-        String dn;
-        KeyPair keyPair;
-        String certificateLocation;
-        IpResourceSet resources;
-        String notifyURI;
-        String manifestURI;
-        String repositoryURI;
-
-        String crlDistributionPoint;
-
-        List<CertificateAuthority> children;
-        List<RoaPrefix> roaPrefixes;
-    }
 }


### PR DESCRIPTION
RPKI objects that are (no longer) referenced from current manifests
are deleted after at least 7 days of unreachability.