### PR TITLE
RTR protocol version 0

### DIFF
--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/RtrServer.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/RtrServer.java
@@ -282,12 +282,8 @@ public class RtrServer {
                 }
 
                 ctx.write(CacheResponsePdu.of(clientProtocolVersion, delta.getSessionId()));
-                if (!delta.getAnnouncements().isEmpty()) {
-                    ctx.write(new ChunkedStream<>(delta.getAnnouncements().stream().map(dataUnit -> dataUnit.toPdu(clientProtocolVersion, Flags.ANNOUNCEMENT))));
-                }
-                if (!delta.getWithdrawals().isEmpty()) {
-                    ctx.write(new ChunkedStream<>(delta.getWithdrawals().stream().map(dataUnit -> dataUnit.toPdu(clientProtocolVersion, Flags.WITHDRAWAL))));
-                }
+                ctx.write(new ChunkedStream<>(delta.getAnnouncements().stream().map(dataUnit -> dataUnit.toPdu(clientProtocolVersion, Flags.ANNOUNCEMENT))));
+                ctx.write(new ChunkedStream<>(delta.getWithdrawals().stream().map(dataUnit -> dataUnit.toPdu(clientProtocolVersion, Flags.WITHDRAWAL))));
                 return ctx.writeAndFlush(EndOfDataPdu.of(clientProtocolVersion, delta.getSessionId(), delta.getSerialNumber(), REFRESH_INTERVAL, RETRY_INTERVAL, EXPIRE_INTERVAL));
             } else {
                 RtrCache.Content content = deltaOrContent.right().value();
@@ -306,9 +302,7 @@ public class RtrServer {
             latestNotifySerialNumber = content.getSerialNumber();
 
             ctx.write(CacheResponsePdu.of(clientProtocolVersion, content.getSessionId()));
-            if (!content.getAnnouncements().isEmpty()) {
-                ctx.write(new ChunkedStream<>(content.getAnnouncements().stream().map(dataUnit -> dataUnit.toPdu(clientProtocolVersion, Flags.ANNOUNCEMENT))));
-            }
+            ctx.write(new ChunkedStream<>(content.getAnnouncements().stream().map(dataUnit -> dataUnit.toPdu(clientProtocolVersion, Flags.ANNOUNCEMENT))));
             return ctx.writeAndFlush(EndOfDataPdu.of(clientProtocolVersion, content.getSessionId(), content.getSerialNumber(), REFRESH_INTERVAL, RETRY_INTERVAL, EXPIRE_INTERVAL));
         }
 

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/adapter/netty/PduCodec.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/adapter/netty/PduCodec.java
@@ -30,22 +30,33 @@
 package net.ripe.rpki.rtr.adapter.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageCodec;
 import lombok.extern.slf4j.Slf4j;
+import net.ripe.rpki.rtr.domain.RtrPrefix;
 import net.ripe.rpki.rtr.domain.SerialNumber;
+import net.ripe.rpki.rtr.domain.pdus.CacheResetPdu;
+import net.ripe.rpki.rtr.domain.pdus.CacheResponsePdu;
+import net.ripe.rpki.rtr.domain.pdus.EndOfDataPdu;
 import net.ripe.rpki.rtr.domain.pdus.ErrorCode;
 import net.ripe.rpki.rtr.domain.pdus.ErrorPdu;
+import net.ripe.rpki.rtr.domain.pdus.Flags;
+import net.ripe.rpki.rtr.domain.pdus.IPv4PrefixPdu;
+import net.ripe.rpki.rtr.domain.pdus.IPv6PrefixPdu;
+import net.ripe.rpki.rtr.domain.pdus.NotifyPdu;
 import net.ripe.rpki.rtr.domain.pdus.Pdu;
-import net.ripe.rpki.rtr.domain.pdus.RtrProtocolException;
 import net.ripe.rpki.rtr.domain.pdus.ProtocolVersion;
 import net.ripe.rpki.rtr.domain.pdus.ResetQueryPdu;
+import net.ripe.rpki.rtr.domain.pdus.RtrProtocolException;
 import net.ripe.rpki.rtr.domain.pdus.SerialQueryPdu;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.BiFunction;
 
+import static net.ripe.rpki.rtr.domain.pdus.ProtocolVersion.V0;
 import static net.ripe.rpki.rtr.domain.pdus.ProtocolVersion.V1;
 
 @Slf4j
@@ -58,8 +69,12 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        parsePdu(in).ifPresent(out::add);
+    }
+
+    public static Optional<Pdu> parsePdu(ByteBuf in) {
         if (in.readableBytes() < 8) {
-            return;
+            return Optional.empty();
         }
 
         in.markReaderIndex();
@@ -82,51 +97,109 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
 
         int pduType = in.readUnsignedByte();
         switch (pduType) {
-            case SerialQueryPdu.PDU_TYPE: {
+            case NotifyPdu.PDU_TYPE: {
                 short sessionId = in.readShort();
-                long length = in.readUnsignedInt();
-                if (length != SerialQueryPdu.PDU_LENGTH) {
-                    throw new RtrProtocolException(generateError.apply(
-                        ErrorCode.InvalidRequest,
-                        String.format("length of Serial Query PDU must be %d, was %d", SerialQueryPdu.PDU_LENGTH, length)
-                    ));
-                }
-                if (in.readableBytes() + 8 < length) {
-                    return;
+                if (!checkLength(in, NotifyPdu.PDU_LENGTH, "Serial Notify", generateError)) {
+                    return Optional.empty();
                 }
                 int serialNumber = in.readInt();
-                out.add(SerialQueryPdu.of(protocolVersion, sessionId, SerialNumber.of(serialNumber)));
-                break;
+                return Optional.of(NotifyPdu.of(protocolVersion, sessionId, SerialNumber.of(serialNumber)));
+            }
+            case SerialQueryPdu.PDU_TYPE: {
+                short sessionId = in.readShort();
+                if (!checkLength(in, SerialQueryPdu.PDU_LENGTH, "Serial Query", generateError)) {
+                    return Optional.empty();
+                }
+                int serialNumber = in.readInt();
+                return Optional.of(SerialQueryPdu.of(protocolVersion, sessionId, SerialNumber.of(serialNumber)));
             }
             case ResetQueryPdu.PDU_TYPE: {
-                @SuppressWarnings("unused") int zero = in.readUnsignedShort();
-                long length = in.readUnsignedInt();
-                if (length != ResetQueryPdu.PDU_LENGTH) {
-                    throw new RtrProtocolException(generateError.apply(
-                        ErrorCode.InvalidRequest,
-                        String.format("length of Reset Query PDU must be %d, was %d", ResetQueryPdu.PDU_LENGTH, length)
-                    ));
+                in.readUnsignedShort(); /* zero */
+                if (!checkLength(in, ResetQueryPdu.PDU_LENGTH, "Reset Query", generateError)) {
+                    return Optional.empty();
                 }
-                out.add(ResetQueryPdu.of(protocolVersion));
-                break;
+                return Optional.of(ResetQueryPdu.of(protocolVersion));
+            }
+            case CacheResponsePdu.PDU_TYPE: {
+                short sessionId = in.readShort();
+                if (!checkLength(in, CacheResponsePdu.PDU_LENGTH, "Cache Response", generateError)) {
+                    return Optional.empty();
+                }
+                return Optional.of(CacheResponsePdu.of(protocolVersion, sessionId));
+            }
+            case IPv4PrefixPdu.PDU_TYPE: {
+                in.readShort(); /* zero */
+                if (!checkLength(in, IPv4PrefixPdu.PDU_LENGTH, "IPv4 Prefix", generateError)) {
+                    return Optional.empty();
+                }
+                Flags flags = (in.readByte() & 0x01) == 0 ? Flags.WITHDRAWAL : Flags.ANNOUNCEMENT;
+                byte prefixLength = in.readByte();
+                byte maxLength = in.readByte();
+                in.readByte(); /* zero */
+                byte[] prefix = ByteBufUtil.getBytes(in.readBytes(4));
+                int asn = in.readInt();
+                return Optional.of(IPv4PrefixPdu.of(protocolVersion, flags, RtrPrefix.of(prefixLength, maxLength, prefix, asn)));
+            }
+            case IPv6PrefixPdu.PDU_TYPE: {
+                in.readShort(); /* zero */
+                if (!checkLength(in, IPv6PrefixPdu.PDU_LENGTH, "IPv6 Prefix", generateError)) {
+                    return Optional.empty();
+                }
+                Flags flags = (in.readByte() & 0x01) == 0 ? Flags.WITHDRAWAL : Flags.ANNOUNCEMENT;
+                byte prefixLength = in.readByte();
+                byte maxLength = in.readByte();
+                in.readByte(); /* zero */
+                byte[] prefix = ByteBufUtil.getBytes(in.readBytes(16));
+                int asn = in.readInt();
+                return Optional.of(IPv4PrefixPdu.of(protocolVersion, flags, RtrPrefix.of(prefixLength, maxLength, prefix, asn)));
+            }
+            case EndOfDataPdu.PDU_TYPE: {
+                short sessionId = in.readShort();
+                switch (protocolVersion) {
+                    case V0: {
+                        if (!checkLength(in, EndOfDataPdu.PDU_LENGTH_V0, "End of Data", generateError)) {
+                            return Optional.empty();
+                        }
+                        int serialNumber = in.readInt();
+                        return Optional.of(EndOfDataPdu.of(V0, sessionId, SerialNumber.of(serialNumber), 3600, 600, 7200));
+                    }
+                    case V1: {
+                        if (!checkLength(in, EndOfDataPdu.PDU_LENGTH_V1, "End of Data", generateError)) {
+                            return Optional.empty();
+                        }
+                        int serialNumber = in.readInt();
+                        int refreshInterval = in.readInt();
+                        int retryInterval = in.readInt();
+                        int expireInterval = in.readInt();
+                        return Optional.of(EndOfDataPdu.of(V1, sessionId, SerialNumber.of(serialNumber), refreshInterval, retryInterval, expireInterval));
+                    }
+                }
+                throw new IllegalStateException("bad protocol version " + protocolVersion);
+            }
+            case CacheResetPdu.PDU_TYPE: {
+                in.readUnsignedShort(); /* zero */
+                if (!checkLength(in, CacheResetPdu.PDU_LENGTH, "Cache Reset", generateError)) {
+                    return Optional.empty();
+                }
+                return Optional.of(CacheResetPdu.of(protocolVersion));
             }
             case ErrorPdu.PDU_TYPE: {
                 int errorCode = in.readUnsignedShort();
                 long length = in.readUnsignedInt();
                 if (length > Pdu.MAX_LENGTH) {
                     throw new RtrProtocolException(generateError.apply(
-                       ErrorCode.InvalidRequest,
-                       String.format("maximum PDU length is %d, was %d", Pdu.MAX_LENGTH, length)
+                        ErrorCode.InvalidRequest,
+                        String.format("maximum PDU length is %d, was %d", Pdu.MAX_LENGTH, length)
                     ));
                 }
                 if (in.readableBytes() + 8 < length) {
-                    return;
+                    return Optional.empty();
                 }
                 long encapsulatedPduLength = in.readUnsignedInt();
                 if (encapsulatedPduLength > length - 16) {
                     throw new RtrProtocolException(generateError.apply(
-                       ErrorCode.InvalidRequest,
-                       String.format("encapsulated PDU length %d exceeds maximum length %d", encapsulatedPduLength, length - 16)
+                        ErrorCode.InvalidRequest,
+                        String.format("encapsulated PDU length %d exceeds maximum length %d", encapsulatedPduLength, length - 16)
                     ));
                 }
                 byte[] encapsulatedPdu = new byte[(int) encapsulatedPduLength];
@@ -142,8 +215,7 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
                 byte[] errorTextBytes = new byte[(int) errorTextLength];
                 in.readBytes(errorTextBytes);
 
-                out.add(ErrorPdu.of(protocolVersion, ErrorCode.of(errorCode), encapsulatedPdu, new String(errorTextBytes, StandardCharsets.UTF_8)));
-                break;
+                return Optional.of(ErrorPdu.of(protocolVersion, ErrorCode.of(errorCode), encapsulatedPdu, new String(errorTextBytes, StandardCharsets.UTF_8)));
             }
             default:
                 throw new RtrProtocolException(generateError.apply(
@@ -151,5 +223,16 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
                     String.format("unsupported PDU type %d", pduType)
                 ));
         }
+    }
+
+    private static boolean checkLength(ByteBuf in, int expectedLength, String pduType, BiFunction<ErrorCode, String, ErrorPdu> generateError) {
+        long length = in.readUnsignedInt();
+        if (length != expectedLength) {
+            throw new RtrProtocolException(generateError.apply(
+                ErrorCode.InvalidRequest,
+                String.format("length of %s PDU must be %d, was %d", pduType, expectedLength, length)
+            ));
+        }
+        return in.readableBytes() + 8 >= length;
     }
 }

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/adapter/netty/PduCodec.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/adapter/netty/PduCodec.java
@@ -37,7 +37,7 @@ import net.ripe.rpki.rtr.domain.SerialNumber;
 import net.ripe.rpki.rtr.domain.pdus.ErrorCode;
 import net.ripe.rpki.rtr.domain.pdus.ErrorPdu;
 import net.ripe.rpki.rtr.domain.pdus.Pdu;
-import net.ripe.rpki.rtr.domain.pdus.PduParseException;
+import net.ripe.rpki.rtr.domain.pdus.RtrProtocolException;
 import net.ripe.rpki.rtr.domain.pdus.ProtocolVersion;
 import net.ripe.rpki.rtr.domain.pdus.ResetQueryPdu;
 import net.ripe.rpki.rtr.domain.pdus.SerialQueryPdu;
@@ -74,7 +74,7 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
         };
 
         if (protocolVersion == null) {
-            throw new PduParseException(generateError.apply(
+            throw new RtrProtocolException(generateError.apply(
                 ErrorCode.UnsupportedProtocolVersion,
                 String.format("protocol version must be 0 or 1, was %d", Byte.toUnsignedInt(protocolVersionValue))
             ));
@@ -86,7 +86,7 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
                 short sessionId = in.readShort();
                 long length = in.readUnsignedInt();
                 if (length != SerialQueryPdu.PDU_LENGTH) {
-                    throw new PduParseException(generateError.apply(
+                    throw new RtrProtocolException(generateError.apply(
                         ErrorCode.InvalidRequest,
                         String.format("length of Serial Query PDU must be %d, was %d", SerialQueryPdu.PDU_LENGTH, length)
                     ));
@@ -102,7 +102,7 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
                 @SuppressWarnings("unused") int zero = in.readUnsignedShort();
                 long length = in.readUnsignedInt();
                 if (length != ResetQueryPdu.PDU_LENGTH) {
-                    throw new PduParseException(generateError.apply(
+                    throw new RtrProtocolException(generateError.apply(
                         ErrorCode.InvalidRequest,
                         String.format("length of Reset Query PDU must be %d, was %d", ResetQueryPdu.PDU_LENGTH, length)
                     ));
@@ -114,7 +114,7 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
                 int errorCode = in.readUnsignedShort();
                 long length = in.readUnsignedInt();
                 if (length > Pdu.MAX_LENGTH) {
-                    throw new PduParseException(generateError.apply(
+                    throw new RtrProtocolException(generateError.apply(
                        ErrorCode.InvalidRequest,
                        String.format("maximum PDU length is %d, was %d", Pdu.MAX_LENGTH, length)
                     ));
@@ -124,7 +124,7 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
                 }
                 long encapsulatedPduLength = in.readUnsignedInt();
                 if (encapsulatedPduLength > length - 16) {
-                    throw new PduParseException(generateError.apply(
+                    throw new RtrProtocolException(generateError.apply(
                        ErrorCode.InvalidRequest,
                        String.format("encapsulated PDU length %d exceeds maximum length %d", encapsulatedPduLength, length - 16)
                     ));
@@ -134,7 +134,7 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
 
                 long errorTextLength = in.readUnsignedInt();
                 if (errorTextLength > length - encapsulatedPduLength - 16) {
-                    throw new PduParseException(generateError.apply(
+                    throw new RtrProtocolException(generateError.apply(
                         ErrorCode.InvalidRequest,
                         String.format("error text length %d exceeds maximum length %d", errorTextLength, length - encapsulatedPduLength - 16)
                     ));
@@ -146,7 +146,7 @@ public class PduCodec extends ByteToMessageCodec<Pdu> {
                 break;
             }
             default:
-                throw new PduParseException(generateError.apply(
+                throw new RtrProtocolException(generateError.apply(
                     ErrorCode.UnsupportedPduType,
                     String.format("unsupported PDU type %d", pduType)
                 ));

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/RtrDataUnit.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/RtrDataUnit.java
@@ -35,12 +35,13 @@ import net.ripe.ipresource.Ipv4Address;
 import net.ripe.ipresource.Ipv6Address;
 import net.ripe.rpki.rtr.domain.pdus.Flags;
 import net.ripe.rpki.rtr.domain.pdus.Pdu;
+import net.ripe.rpki.rtr.domain.pdus.ProtocolVersion;
 
 import java.util.Arrays;
 
 public interface RtrDataUnit extends Comparable<RtrDataUnit> {
 
-    Pdu toPdu(Flags flags);
+    Pdu toPdu(ProtocolVersion protocolVersion, Flags flags);
 
     static RtrPrefix prefix(Asn asn, IpRange ipRange, Integer maxLength) {
         if (ipRange.getStart() instanceof Ipv4Address) {

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/RtrPrefix.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/RtrPrefix.java
@@ -34,6 +34,7 @@ import net.ripe.rpki.rtr.domain.pdus.Flags;
 import net.ripe.rpki.rtr.domain.pdus.IPv4PrefixPdu;
 import net.ripe.rpki.rtr.domain.pdus.IPv6PrefixPdu;
 import net.ripe.rpki.rtr.domain.pdus.Pdu;
+import net.ripe.rpki.rtr.domain.pdus.ProtocolVersion;
 import org.bouncycastle.util.Arrays;
 
 @Value(staticConstructor = "of")
@@ -44,11 +45,11 @@ public class RtrPrefix implements RtrDataUnit {
     int asn;
 
     @Override
-    public Pdu toPdu(Flags flags) {
+    public Pdu toPdu(ProtocolVersion protocolVersion, Flags flags) {
         if (prefix.length == 4) {
-            return IPv4PrefixPdu.of(flags, this);
+            return IPv4PrefixPdu.of(protocolVersion, flags, this);
         } else if (prefix.length == 16) {
-            return IPv6PrefixPdu.of(flags, this);
+            return IPv6PrefixPdu.of(protocolVersion, flags, this);
         } else {
             throw new IllegalStateException(String.format("invalid RTR prefix length, expected 4 or 16, was %d", prefix.length));
         }

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/CacheResetPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/CacheResetPdu.java
@@ -40,6 +40,8 @@ public class CacheResetPdu implements Pdu {
     public static final int PDU_TYPE = 8;
     public static final int PDU_LENGTH = 8;
 
+    ProtocolVersion protocolVersion;
+
     @Override
     public int length() {
         return PDU_LENGTH;
@@ -48,7 +50,7 @@ public class CacheResetPdu implements Pdu {
     @Override
     public void write(ByteBuf out) {
         out
-            .writeByte(PROTOCOL_VERSION)
+            .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
             .writeShort(0)
             .writeInt(length());

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/CacheResponsePdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/CacheResponsePdu.java
@@ -38,13 +38,14 @@ import lombok.Value;
 @Value(staticConstructor = "of")
 public class CacheResponsePdu implements Pdu {
     public final static int PDU_TYPE = 3;
+    public static final int PDU_LENGTH = 8;
 
     ProtocolVersion protocolVersion;
     short sessionId;
 
     @Override
     public int length() {
-        return 8;
+        return PDU_LENGTH;
     }
 
     @Override

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/CacheResponsePdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/CacheResponsePdu.java
@@ -39,6 +39,7 @@ import lombok.Value;
 public class CacheResponsePdu implements Pdu {
     public final static int PDU_TYPE = 3;
 
+    ProtocolVersion protocolVersion;
     short sessionId;
 
     @Override
@@ -49,7 +50,7 @@ public class CacheResponsePdu implements Pdu {
     @Override
     public void write(ByteBuf out) {
         out
-            .writeByte(PROTOCOL_VERSION)
+            .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
             .writeShort(sessionId)
             .writeInt(length());

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/EndOfDataPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/EndOfDataPdu.java
@@ -40,6 +40,8 @@ import net.ripe.rpki.rtr.domain.SerialNumber;
 public class EndOfDataPdu implements Pdu {
 
     public static final int PDU_TYPE = 7;
+    public static final int PDU_LENGTH_V0 = 12;
+    public static final int PDU_LENGTH_V1 = 24;
 
     ProtocolVersion protocolVersion;
     short sessionId;
@@ -52,9 +54,9 @@ public class EndOfDataPdu implements Pdu {
     public int length() {
         switch (protocolVersion) {
             case V0:
-                return 12;
+                return PDU_LENGTH_V0;
             case V1:
-                return 24;
+                return PDU_LENGTH_V1;
         }
         throw new IllegalStateException("bad protocol version " + protocolVersion);
     }
@@ -65,13 +67,13 @@ public class EndOfDataPdu implements Pdu {
             .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
             .writeShort(sessionId)
-            .writeInt(length());
+            .writeInt(length())
+            .writeInt(serialNumber.getValue());
         switch (protocolVersion) {
             case V0:
                 return;
             case V1:
                 out
-                    .writeInt(serialNumber.getValue())
                     .writeInt(refreshInterval)
                     .writeInt(retryInterval)
                     .writeInt(expireInterval);

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/EndOfDataPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/EndOfDataPdu.java
@@ -41,6 +41,7 @@ public class EndOfDataPdu implements Pdu {
 
     public static final int PDU_TYPE = 7;
 
+    ProtocolVersion protocolVersion;
     short sessionId;
     SerialNumber serialNumber;
     int refreshInterval;
@@ -49,19 +50,33 @@ public class EndOfDataPdu implements Pdu {
 
     @Override
     public int length() {
-        return 24;
+        switch (protocolVersion) {
+            case V0:
+                return 12;
+            case V1:
+                return 24;
+        }
+        throw new IllegalStateException("bad protocol version " + protocolVersion);
     }
 
     @Override
     public void write(ByteBuf out) {
         out
-            .writeByte(PROTOCOL_VERSION)
+            .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
             .writeShort(sessionId)
-            .writeInt(length())
-            .writeInt(serialNumber.getValue())
-            .writeInt(refreshInterval)
-            .writeInt(retryInterval)
-            .writeInt(expireInterval);
+            .writeInt(length());
+        switch (protocolVersion) {
+            case V0:
+                return;
+            case V1:
+                out
+                    .writeInt(serialNumber.getValue())
+                    .writeInt(refreshInterval)
+                    .writeInt(retryInterval)
+                    .writeInt(expireInterval);
+                return;
+        }
+        throw new IllegalStateException("bad protocol version " + protocolVersion);
     }
 }

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ErrorCode.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ErrorCode.java
@@ -38,7 +38,8 @@ public enum ErrorCode {
     UnsupportedProtocolVersion(4),
     UnsupportedPduType(5),
     WithdrawalOfUnknownRecord(6),
-    DuplicateAnnouncementReceived(7);
+    DuplicateAnnouncementReceived(7),
+    UnexpectedProtocolVersion(8);
 
     final int code;
 
@@ -46,7 +47,7 @@ public enum ErrorCode {
         this.code = i;
     }
 
-    boolean isFatal() {
+    public boolean isFatal() {
         return code != NoDataAvailable.code;
     }
 

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ErrorCode.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ErrorCode.java
@@ -29,6 +29,8 @@
  */
 package net.ripe.rpki.rtr.domain.pdus;
 
+import lombok.Getter;
+
 public enum ErrorCode {
 
     CorruptData(0),
@@ -41,7 +43,8 @@ public enum ErrorCode {
     DuplicateAnnouncementReceived(7),
     UnexpectedProtocolVersion(8);
 
-    final int code;
+    @Getter
+    private final int code;
 
     ErrorCode(int i) {
         this.code = i;

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ErrorPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ErrorPdu.java
@@ -41,6 +41,7 @@ import java.nio.charset.StandardCharsets;
 public class ErrorPdu implements Pdu {
     public static final int PDU_TYPE = 10;
 
+    ProtocolVersion protocolVersion;
     ErrorCode errorCode;
     byte[] causingPdu;
     String errorText;
@@ -60,7 +61,7 @@ public class ErrorPdu implements Pdu {
     public void write(ByteBuf out) {
         final byte[] errorTextBytes = errorTextBytes();
         out
-            .writeByte(PROTOCOL_VERSION)
+            .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
             .writeShort(0)
             .writeInt(length())

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ErrorPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ErrorPdu.java
@@ -35,7 +35,7 @@ import lombok.Value;
 import java.nio.charset.StandardCharsets;
 
 /**
- * @see <a href="https://tools.ietf.org/html/rfc8210#section-5.6">RFC8210 section 5.6 - IPv4 Prefix</a>
+ * @see <a href="https://tools.ietf.org/html/rfc8210#section-5.11">RFC8210 section 5.11 - Error Report</a>
  */
 @Value(staticConstructor = "of")
 public class ErrorPdu implements Pdu {
@@ -45,10 +45,6 @@ public class ErrorPdu implements Pdu {
     ErrorCode errorCode;
     byte[] causingPdu;
     String errorText;
-
-    short headerShort() {
-        return (short) errorCode.code;
-    }
 
     public int length() {
         return 8 + 4 + causingPdu.length + 4 + errorTextBytes().length;
@@ -63,8 +59,9 @@ public class ErrorPdu implements Pdu {
         out
             .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
-            .writeShort(0)
+            .writeShort(errorCode.getCode())
             .writeInt(length())
+            .writeInt(causingPdu.length)
             .writeBytes(causingPdu)
             .writeInt(errorTextBytes.length)
             .writeBytes(errorTextBytes);

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/IPv4PrefixPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/IPv4PrefixPdu.java
@@ -39,6 +39,7 @@ import net.ripe.rpki.rtr.domain.RtrPrefix;
 @Value(staticConstructor = "of")
 public class IPv4PrefixPdu implements Pdu {
     public static final int PDU_TYPE = 4;
+    public static final int PDU_LENGTH = 20;
 
     ProtocolVersion protocolVersion;
     Flags flags;
@@ -61,6 +62,6 @@ public class IPv4PrefixPdu implements Pdu {
 
     @Override
     public int length() {
-        return 20;
+        return PDU_LENGTH;
     }
 }

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/IPv4PrefixPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/IPv4PrefixPdu.java
@@ -40,13 +40,14 @@ import net.ripe.rpki.rtr.domain.RtrPrefix;
 public class IPv4PrefixPdu implements Pdu {
     public static final int PDU_TYPE = 4;
 
+    ProtocolVersion protocolVersion;
     Flags flags;
     RtrPrefix prefix;
 
     @Override
     public void write(ByteBuf out) {
         out
-            .writeByte(PROTOCOL_VERSION)
+            .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
             .writeShort(0)
             .writeInt(length())

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/IPv6PrefixPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/IPv6PrefixPdu.java
@@ -39,6 +39,7 @@ import net.ripe.rpki.rtr.domain.RtrPrefix;
 @Value(staticConstructor = "of")
 public class IPv6PrefixPdu implements Pdu {
     public static final int PDU_TYPE = 6;
+    public static final int PDU_LENGTH = 32;
 
     ProtocolVersion protocolVersion;
     Flags flags;
@@ -61,6 +62,6 @@ public class IPv6PrefixPdu implements Pdu {
 
     @Override
     public int length() {
-        return 32;
+        return PDU_LENGTH;
     }
 }

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/NotifyPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/NotifyPdu.java
@@ -39,7 +39,8 @@ import net.ripe.rpki.rtr.domain.SerialNumber;
 @Value(staticConstructor = "of")
 public class NotifyPdu implements Pdu {
 
-    private static final int PDU_TYPE = 0;
+    public static final int PDU_TYPE = 0;
+    public static final int PDU_LENGTH = 12;
 
     ProtocolVersion protocolVersion;
     short sessionId;
@@ -47,7 +48,7 @@ public class NotifyPdu implements Pdu {
 
     @Override
     public int length() {
-        return 12;
+        return PDU_LENGTH;
     }
 
     @Override

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/NotifyPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/NotifyPdu.java
@@ -41,8 +41,8 @@ public class NotifyPdu implements Pdu {
 
     private static final int PDU_TYPE = 0;
 
+    ProtocolVersion protocolVersion;
     short sessionId;
-
     SerialNumber serialNumber;
 
     @Override
@@ -53,7 +53,7 @@ public class NotifyPdu implements Pdu {
     @Override
     public void write(ByteBuf out) {
         out
-                .writeByte(PROTOCOL_VERSION)
+                .writeByte(protocolVersion.getValue())
                 .writeByte(PDU_TYPE)
                 .writeShort(sessionId)
                 .writeInt(length())

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/Pdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/Pdu.java
@@ -30,11 +30,13 @@
 package net.ripe.rpki.rtr.domain.pdus;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 
 public interface Pdu {
     int MAX_LENGTH = 3248; // Taken from RTR lib
-    int PROTOCOL_VERSION = 1;
+
+    ProtocolVersion getProtocolVersion();
 
     int length();
 
@@ -43,6 +45,6 @@ public interface Pdu {
     default byte[] toByteArray() {
         ByteBuf out = Unpooled.buffer(length());
         this.write(out);
-        return out.array();
+        return ByteBufUtil.getBytes(out);
     }
 }

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ProtocolVersion.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ProtocolVersion.java
@@ -29,38 +29,35 @@
  */
 package net.ripe.rpki.rtr.domain.pdus;
 
-import io.netty.buffer.ByteBuf;
-import lombok.Value;
-import net.ripe.rpki.rtr.domain.RtrPrefix;
+import lombok.Getter;
 
-/**
- * @see <a href="https://tools.ietf.org/html/rfc8210#section-5.7">RFC8210 section 5.7 - IPv6 Prefix</a>
- */
-@Value(staticConstructor = "of")
-public class IPv6PrefixPdu implements Pdu {
-    public static final int PDU_TYPE = 6;
+public enum ProtocolVersion {
+    /**
+     * <a href="https://tools.ietf.org/rfc/rfc6810">RFC6810 - The Resource Public Key Infrastructure (RPKI) to Router Protocol</a>
+     */
+    V0(0),
 
-    ProtocolVersion protocolVersion;
-    Flags flags;
-    RtrPrefix prefix;
+    /**
+     * <a href="https://tools.ietf.org/rfc/rfc8210">RFC8210 - The Resource Public Key Infrastructure (RPKI) to Router Protocol,
+     * Version 1</a>
+     */
+    V1(1);
 
-    @Override
-    public void write(ByteBuf out) {
-        out
-            .writeByte(protocolVersion.getValue())
-            .writeByte(PDU_TYPE)
-            .writeShort(0)
-            .writeInt(length())
-            .writeByte(flags.getFlags())
-            .writeByte(prefix.getPrefixLength())
-            .writeByte(prefix.getMaxLength())
-            .writeByte(0)
-            .writeBytes(prefix.getPrefix())
-            .writeInt(prefix.getAsn());
+    @Getter
+    private final byte value;
+
+    ProtocolVersion(int value) {
+        this.value = (byte) value;
     }
 
-    @Override
-    public int length() {
-        return 32;
+    public static ProtocolVersion of(byte value) {
+        switch (value) {
+            case 0:
+                return V0;
+            case 1:
+                return V1;
+            default:
+                return null;
+        }
     }
 }

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ResetQueryPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/ResetQueryPdu.java
@@ -40,6 +40,8 @@ public class ResetQueryPdu implements Pdu {
     public static final int PDU_TYPE = 2;
     public static final int PDU_LENGTH = 8;
 
+    ProtocolVersion protocolVersion;
+
     @Override
     public int length() {
         return PDU_LENGTH;
@@ -48,7 +50,7 @@ public class ResetQueryPdu implements Pdu {
     @Override
     public void write(ByteBuf out) {
         out
-            .writeByte(PROTOCOL_VERSION)
+            .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
             .writeShort(0)
             .writeInt(length());

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/RtrProtocolException.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/RtrProtocolException.java
@@ -31,10 +31,11 @@ package net.ripe.rpki.rtr.domain.pdus;
 
 import lombok.Getter;
 
-public class PduParseException extends RuntimeException {
+public class RtrProtocolException extends RuntimeException {
     @Getter
     private final ErrorPdu errorPdu;
-    public PduParseException(ErrorPdu errorPdu) {
+
+    public RtrProtocolException(ErrorPdu errorPdu) {
         super(errorPdu.getErrorText());
         this.errorPdu = errorPdu;
     }

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/SerialQueryPdu.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/pdus/SerialQueryPdu.java
@@ -41,6 +41,7 @@ public class SerialQueryPdu implements Pdu {
     public static final int PDU_TYPE = 1;
     public static final int PDU_LENGTH = 12;
 
+    ProtocolVersion protocolVersion;
     short sessionId;
     SerialNumber serialNumber;
 
@@ -52,7 +53,7 @@ public class SerialQueryPdu implements Pdu {
     @Override
     public void write(ByteBuf out) {
         out
-            .writeByte(PROTOCOL_VERSION)
+            .writeByte(protocolVersion.getValue())
             .writeByte(PDU_TYPE)
             .writeShort(sessionId)
             .writeInt(length())

--- a/rpki-rtr-server/src/test/java/net/ripe/rpki/rtr/RtrServerTest.java
+++ b/rpki-rtr-server/src/test/java/net/ripe/rpki/rtr/RtrServerTest.java
@@ -268,12 +268,13 @@ public class RtrServerTest {
     private void assertResponse(Pdu... expectedResponses) {
         for (Pdu expected : expectedResponses) {
             try {
-                Pdu actual = null;
-                ByteBuf msg = channel.readOutbound();
-                if (msg != null) {
-                    actual = PduCodec.parsePdu(msg).orElse(null);
+                for (ByteBuf msg = channel.readOutbound(); msg != null; msg = channel.readOutbound()) {
+                    Pdu actual = PduCodec.parsePdu(msg).orElse(null);
+                    if (actual != null) {
+                        assertEquals(expected, actual);
+                        break;
+                    }
                 }
-                assertEquals(expected, actual);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/rpki-rtr-server/src/test/java/net/ripe/rpki/rtr/domain/pdus/PduTest.java
+++ b/rpki-rtr-server/src/test/java/net/ripe/rpki/rtr/domain/pdus/PduTest.java
@@ -29,9 +29,7 @@
  */
 package net.ripe.rpki.rtr.domain.pdus;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
 import net.ripe.ipresource.Asn;
 import net.ripe.ipresource.IpRange;
 import net.ripe.ipresource.Ipv4Address;
@@ -40,6 +38,7 @@ import net.ripe.rpki.rtr.domain.RtrDataUnit;
 import org.assertj.core.util.Strings;
 import org.junit.Test;
 
+import static net.ripe.rpki.rtr.domain.pdus.ProtocolVersion.V1;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class PduTest {
@@ -47,7 +46,7 @@ public class PduTest {
     @Test
     public void should_write_ipv4_prefix_pdu() {
         // https://tools.ietf.org/html/rfc8210#section-5.6
-        assertThat(write(IPv4PrefixPdu.of(Flags.ANNOUNCEMENT, RtrDataUnit.prefix(Asn.parse("3333"), IpRange.prefix(Ipv4Address.parse("127.0.0.0"), 8), 18)))).isEqualToIgnoringWhitespace(Strings.concat(
+        assertThat(write(IPv4PrefixPdu.of(V1, Flags.ANNOUNCEMENT, RtrDataUnit.prefix(Asn.parse("3333"), IpRange.prefix(Ipv4Address.parse("127.0.0.0"), 8), 18)))).isEqualToIgnoringWhitespace(Strings.concat(
             "01 04 00 00",
             "00 00 00 14",
             "01 08 12 00",
@@ -55,7 +54,7 @@ public class PduTest {
             "00 00 0d 05"
         ));
 
-        assertThat(write(IPv4PrefixPdu.of(Flags.WITHDRAWAL, RtrDataUnit.prefix(Asn.parse("" + Asn.ASN32_MAX_VALUE), IpRange.prefix(Ipv4Address.parse("255.255.255.255"), 32), null)))).isEqualToIgnoringWhitespace(Strings.concat(
+        assertThat(write(IPv4PrefixPdu.of(V1, Flags.WITHDRAWAL, RtrDataUnit.prefix(Asn.parse("" + Asn.ASN32_MAX_VALUE), IpRange.prefix(Ipv4Address.parse("255.255.255.255"), 32), null)))).isEqualToIgnoringWhitespace(Strings.concat(
             "01 04 00 00",
             "00 00 00 14",
             "00 20 20 00",
@@ -66,7 +65,7 @@ public class PduTest {
 
     @Test
     public void should_write_ipv6_prefix_pdu() {
-        assertThat(write(IPv6PrefixPdu.of(Flags.ANNOUNCEMENT, RtrDataUnit.prefix(Asn.parse("3333"), IpRange.prefix(Ipv6Address.parse("2001:67c:2e8:110::"), 64), 80)))).isEqualToIgnoringWhitespace(Strings.concat(
+        assertThat(write(IPv6PrefixPdu.of(V1, Flags.ANNOUNCEMENT, RtrDataUnit.prefix(Asn.parse("3333"), IpRange.prefix(Ipv6Address.parse("2001:67c:2e8:110::"), 64), 80)))).isEqualToIgnoringWhitespace(Strings.concat(
             "01 06 00 00",
             "00 00 00 20",
             "01 40 50 00",
@@ -74,7 +73,7 @@ public class PduTest {
             "00 00 0d 05"
         ));
 
-        assertThat(write(IPv6PrefixPdu.of(Flags.WITHDRAWAL, RtrDataUnit.prefix(Asn.parse("" + Asn.ASN32_MAX_VALUE), IpRange.prefix(Ipv6Address.parse("::1"), 128), null)))).isEqualToIgnoringWhitespace(Strings.concat(
+        assertThat(write(IPv6PrefixPdu.of(V1, Flags.WITHDRAWAL, RtrDataUnit.prefix(Asn.parse("" + Asn.ASN32_MAX_VALUE), IpRange.prefix(Ipv6Address.parse("::1"), 128), null)))).isEqualToIgnoringWhitespace(Strings.concat(
             "01 06 00 00",
             "00 00 00 20",
             "00 80 80 00",
@@ -86,7 +85,7 @@ public class PduTest {
     @Test
     public void should_write_error_pdu() {
         final byte[] bytes = new byte[]{1, 2, 3, 4};
-        ErrorPdu errorPdu = ErrorPdu.of(ErrorCode.InvalidRequest, bytes, "error text");
+        ErrorPdu errorPdu = ErrorPdu.of(V1, ErrorCode.InvalidRequest, bytes, "error text");
         assertThat(write(errorPdu)).isEqualToIgnoringWhitespace(Strings.concat(
                 "01 0a 00 00" +
                         "00 00 00 1e" +
@@ -97,8 +96,6 @@ public class PduTest {
     }
 
     private String write(Pdu pdu) {
-        ByteBuf buffer = Unpooled.buffer();
-        pdu.write(buffer);
-        return ByteBufUtil.hexDump(buffer);
+        return ByteBufUtil.hexDump(pdu.toByteArray());
     }
 }

--- a/rpki-rtr-server/src/test/java/net/ripe/rpki/rtr/domain/pdus/PduTest.java
+++ b/rpki-rtr-server/src/test/java/net/ripe/rpki/rtr/domain/pdus/PduTest.java
@@ -87,8 +87,9 @@ public class PduTest {
         final byte[] bytes = new byte[]{1, 2, 3, 4};
         ErrorPdu errorPdu = ErrorPdu.of(V1, ErrorCode.InvalidRequest, bytes, "error text");
         assertThat(write(errorPdu)).isEqualToIgnoringWhitespace(Strings.concat(
-                "01 0a 00 00" +
+                "01 0a 00 03" +
                         "00 00 00 1e" +
+                        "00 00 00 04" +
                         "01 02 03 04" +
                         "00 00 00 0a" +
                         "65 72 72 6f 72 20 74 65 78 74"


### PR DESCRIPTION
Implements protocol version 0 including fallback when a version 0 client connects.

When merging with the router key branch the router PDUs should not write anything for protocol version 0, since this version does not support these PDU types.