### PR TITLE
DB-1367: add separate files with internal and default properties

### DIFF
--- a/rpki-rtr-server/pom.xml
+++ b/rpki-rtr-server/pom.xml
@@ -346,6 +346,7 @@
                                     <location>src/main/resources/packaging/centos7/etc/rpki-rtr-server/</location>
                                     <includes>
                                         <include>application.properties</include>
+                                        <include>application-defaults.properties</include>
                                     </includes>
                                 </source>
                             </sources>

--- a/rpki-rtr-server/pom.xml
+++ b/rpki-rtr-server/pom.xml
@@ -312,8 +312,6 @@
                     <mappings>
                         <mapping>
                             <directory>/usr/lib/</directory>
-                            <username>rpki</username>
-                            <groupname>rpki</groupname>
                             <directoryIncluded>false</directoryIncluded>
                             <sources>
                                 <source>
@@ -325,8 +323,6 @@
                         <mapping>
                             <directory>/usr/bin/</directory>
                             <filemode>755</filemode>
-                            <username>rpki</username>
-                            <groupname>rpki</groupname>
                             <directoryIncluded>false</directoryIncluded>
                             <sources>
                                 <source>
@@ -346,6 +342,19 @@
                                     <location>src/main/resources/packaging/centos7/etc/rpki-rtr-server/</location>
                                     <includes>
                                         <include>application.properties</include>
+                                    </includes>
+                                </source>
+                            </sources>
+                        </mapping>
+                        <mapping>
+                            <directory>/etc/rpki-rtr-server/</directory>
+                            <configuration>false</configuration>
+                            <filemode>444</filemode>
+                            <directoryIncluded>false</directoryIncluded>
+                            <sources>
+                                <source>
+                                    <location>src/main/resources/packaging/centos7/etc/rpki-rtr-server/</location>
+                                    <includes>
                                         <include>application-defaults.properties</include>
                                     </includes>
                                 </source>
@@ -354,8 +363,6 @@
                         <mapping>
                             <directory>/etc/systemd/system/</directory>
                             <configuration>true</configuration>
-                            <username>rpki</username>
-                            <groupname>rpki</groupname>
                             <directoryIncluded>false</directoryIncluded>
                             <sources>
                                 <source>
@@ -369,8 +376,6 @@
                         <mapping>
                             <directory>/var/lib/rpki-rtr-server/</directory>
                             <configuration>true</configuration>
-                            <username>rpki</username>
-                            <groupname>rpki</groupname>
                             <directoryIncluded>true</directoryIncluded>
                             <recurseDirectories>true</recurseDirectories>
                             <sources>

--- a/rpki-rtr-server/src/main/resources/packaging/centos7/etc/rpki-rtr-server/application-defaults.properties
+++ b/rpki-rtr-server/src/main/resources/packaging/centos7/etc/rpki-rtr-server/application-defaults.properties
@@ -28,3 +28,47 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+#
+# This is the port for the API, health checks, and future UI
+#
+# Note that we do not recommend exposing this externally. If you must,
+# then we recommend that an HTTPS proxy is used, and access is restricted
+#
+# We plan to include example config for such a proxy setup in future
+server.port=8081
+
+#
+# This is the port for the (plain TCP) RPKI-RTR server
+# Note that according to the RFCs this should be 323, but we would need to
+# run the service as root to bind to that port. Most clients support that
+# a different port is used.
+#
+# If you must use 323 here, then iptables port NAT may help
+rtr.server.port=8323
+
+#
+# Point this variable to where your rpki-validator-3 is running.
+rpki.validator.validated.objects.uri=http://localhost:8080/objects/validated
+
+# Use the following settings to change JVM parameters
+#
+# Change the initial and maximum memory for the JVM
+#
+# Notes:
+# - 128 MB should be enough to cache the validated objects
+jvm.memory.initial=128m      # -Xms jvm option -> initial memory claimed by the jvm
+jvm.memory.maximum=128m      # -Xmx jvm option -> maximum memory for the jvm
+
+
+#
+# Default values as recommanded by RFC 8210
+rtr.client.refresh.interval=3600
+rtr.client.retry.interval=600
+rtr.client.expire.interval=7200
+
+
+########################
+# There should be no need to modify any of the following directives
+
+logging.level.net.ripe.rpki.rtr=INFO
+logging.level.org.springframework.context.annotation=INFO

--- a/rpki-rtr-server/src/main/resources/packaging/centos7/etc/rpki-rtr-server/application.properties
+++ b/rpki-rtr-server/src/main/resources/packaging/centos7/etc/rpki-rtr-server/application.properties
@@ -48,46 +48,13 @@ rtr.server.port=8323
 
 #
 # Point this variable to where your rpki-validator-3 is running.
-rpki.validator.validated.roas.uri=http://localhost:8080/roas/validated
-
-#
-# The following directive is used to set where the rpki-rtr-server keeps its
-# database.
-#
-# Note that the database cannot be shared by multiple instances
-spring.datasource.url=jdbc:h2:file:/var/lib/rpki-rtr-server/db/rpki-rtr-serve.h2
+rpki.validator.validated.objects.uri=http://localhost:8080/objects/validated
 
 # Use the following settings to change JVM parameters
 #
 # Change the initial and maximum memory for the JVM
 #
 # Notes:
-# - 512 MB should be more than enough to cache the Validated ROA Prefixes
-jvm.memory.initial=256m       # -Xms jvm option -> initial memory claimed by the jvm
-jvm.memory.maximum=512m      # -Xmx jvm option -> maximum memory for the jvm
-
-
-####################################
-# The settings below should never be modified
-####################################
-
-endpoints.enabled=false
-endpoints.health.enabled=true
-
-spring.datasource.name=rpki
-spring.datasource.username=rpki
-spring.datasource.password=rpki
-
-spring.mvc.message-codes-resolver.format=POSTFIX_ERROR_CODE
-
-spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.properties.hibernate.show_sql=false
-spring.jpa.properties.hibernate.use_sql_comments=true
-spring.jpa.properties.hibernate.format_sql=true
-
-logging.level.net.ripe.rpki.validator3=INFO
-logging.level.org.springframework.context.annotation=INFO
-
-
-spring.jackson.date-format=yyyy-MM-dd hh:mm:ss
-
+# - 128 MB should be enough to cache the validated objects
+jvm.memory.initial=128m      # -Xms jvm option -> initial memory claimed by the jvm
+jvm.memory.maximum=128m      # -Xmx jvm option -> maximum memory for the jvm

--- a/rpki-rtr-server/src/main/resources/packaging/centos7/usr/bin/rpki-rtr-server.sh
+++ b/rpki-rtr-server/src/main/resources/packaging/centos7/usr/bin/rpki-rtr-server.sh
@@ -34,12 +34,13 @@ cd ${EXECUTION_DIR}
 
 JAVA_CMD="/usr/bin/java"
 APP_NAME="rpki-rtr-server"
-CONFIG_FILE="/etc/${APP_NAME}/application.properties"
+CONFIG_DIR="/etc/${APP_NAME}"
+CONFIG_FILE="${CONFIG_DIR}/application.properties"
 JAR="/usr/lib/${APP_NAME}.jar"
 
 function parse_config_line {
     local CONFIG_KEY=$1
-    local VALUE=`grep "^$CONFIG_KEY" $CONFIG_FILE | sed 's/#.*//g' | awk -F "=" '{ print $2 }'`
+    local VALUE=`grep "^$CONFIG_KEY" "$CONFIG_FILE" | sed 's/#.*//g' | awk -F "=" '{ print $2 }'`
 
     if [ -z $VALUE ]; then
         error_exit "Cannot find value for: $CONFIG_KEY in config-file: $CONFIG_FILE"
@@ -52,4 +53,4 @@ parse_config_line "jvm.memory.maximum" JVM_XMX
 
 MEM_OPTIONS="-Xms$JVM_XMS -Xmx$JVM_XMX"
 
-${JAVA_CMD} ${MEM_OPTIONS} -Dapp.name="${APP_NAME}" -Dspring.config.location="file:${CONFIG_FILE}" -jar "${JAR}"
+exec ${JAVA_CMD} ${MEM_OPTIONS} -Dapp.name="${APP_NAME}" -Dspring.config.location="classpath:/application.properties,file:${CONFIG_DIR}/application-defaults.properties,file:${CONFIG_FILE}" -jar "${JAR}"

--- a/rpki-validator/pom.xml
+++ b/rpki-validator/pom.xml
@@ -337,6 +337,7 @@
                                     <location>src/main/resources/packaging/centos7/etc/rpki-validator-3/</location>
                                     <includes>
                                         <include>application.properties</include>
+                                        <include>application-defaults.properties</include>
                                     </includes>
                                 </source>
                             </sources>

--- a/rpki-validator/pom.xml
+++ b/rpki-validator/pom.xml
@@ -303,8 +303,6 @@
                     <mappings>
                         <mapping>
                             <directory>/usr/lib/</directory>
-                            <username>rpki</username>
-                            <groupname>rpki</groupname>
                             <directoryIncluded>false</directoryIncluded>
                             <sources>
                                 <source>
@@ -316,8 +314,6 @@
                         <mapping>
                             <directory>/usr/bin/</directory>
                             <filemode>755</filemode>
-                            <username>rpki</username>
-                            <groupname>rpki</groupname>
                             <directoryIncluded>false</directoryIncluded>
                             <sources>
                                 <source>
@@ -337,6 +333,19 @@
                                     <location>src/main/resources/packaging/centos7/etc/rpki-validator-3/</location>
                                     <includes>
                                         <include>application.properties</include>
+                                    </includes>
+                                </source>
+                            </sources>
+                        </mapping>
+                        <mapping>
+                            <directory>/etc/rpki-validator-3/</directory>
+                            <configuration>false</configuration>
+                            <filemode>444</filemode>
+                            <directoryIncluded>false</directoryIncluded>
+                            <sources>
+                                <source>
+                                    <location>src/main/resources/packaging/centos7/etc/rpki-validator-3/</location>
+                                    <includes>
                                         <include>application-defaults.properties</include>
                                     </includes>
                                 </source>
@@ -345,8 +354,6 @@
                         <mapping>
                             <directory>/etc/systemd/system/</directory>
                             <configuration>true</configuration>
-                            <username>rpki</username>
-                            <groupname>rpki</groupname>
                             <directoryIncluded>false</directoryIncluded>
                             <sources>
                                 <source>
@@ -360,8 +367,6 @@
                         <mapping>
                             <directory>/var/lib/rpki-validator-3/</directory>
                             <configuration>true</configuration>
-                            <username>rpki</username>
-                            <groupname>rpki</groupname>
                             <directoryIncluded>true</directoryIncluded>
                             <recurseDirectories>true</recurseDirectories>
                             <sources>

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/Validator3Application.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/Validator3Application.java
@@ -38,6 +38,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class Validator3Application {
 
 	public static void main(String[] args) {
-		SpringApplication.run(Validator3Application.class, args);
+	    SpringApplication.run(Validator3Application.class, args);
 	}
 }

--- a/rpki-validator/src/main/resources/packaging/centos7/etc/rpki-validator-3/application-defaults.properties
+++ b/rpki-validator/src/main/resources/packaging/centos7/etc/rpki-validator-3/application-defaults.properties
@@ -35,40 +35,48 @@
 # then we recommend that an HTTPS proxy is used, and access is restricted
 #
 # We plan to include example config for such a proxy setup in future
-server.port=9177
+server.port=8080
 
 #
-# This is the port for the (plain TCP) RPKI-RTR server
-# Note that according to the RFCs this should be 323, but we would need to
-# run the service as root to bind to that port. Most clients support that
-# a different port is used.
+# The following directive is used to set where the rpki-validator keeps its
+# database.
 #
-# If you must use 323 here, then iptables port NAT may help
-rtr.server.port=9178
+# Note that the database cannot be shared by multiple instances
+spring.datasource.url=jdbc:h2:file:/var/lib/rpki-validator-3/db/rpki-validator.h2
 
 #
-# Point this variable to where your rpki-validator-3 is running.
-rpki.validator.validated.objects.uri=http://localhost:8080/objects/validated
+# The following directive is used to set where preconfigured TALs that ship with
+# the RPM can be found. This is only used when the rpki-validator-3 is first started.
+# If you wish to add (or remove) a TAL later, you will need to use the API for now.
+# A UI option may be added for this in future.
+rpki.validator.preconfigured.trust.anchors.directory=/var/lib/rpki-validator-3/preconfigured-tals
 
 #
-# Default values as recommanded by RFC 8210
-rtr.client.refresh.interval=3600
-rtr.client.retry.interval=600
-rtr.client.expire.interval=7200
+# The following directive is used to set where files retrieved from rsync based RPKI
+# repositories are kept.
+rpki.validator.rsync.local.storage.directory=/var/lib/rpki-validator-3/rsync
 
 
 ########################
 # There should be no need to modify any of the following directives
 
-logging.level.net.ripe.rpki.rtr=INFO
+spring.datasource.name=rpki
+spring.datasource.username=rpki
+spring.datasource.password=rpki
+
+logging.level.net.ripe.rpki.validator3=INFO
 logging.level.org.springframework.context.annotation=INFO
 
+# Interval between checking rsync repositories for updates. This
+# parameter is directly passed to [Duration#parse]
+# (https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-).
+# The default value is 10 minutes.
+rpki.validator.rsync.repository.download.interval=PT10M
 
-####################################
-# The settings below should never be modified
-####################################
+rpki.validator.rrdp.trust.all.tls.certificates=true
 
-endpoints.enabled=false
-endpoints.health.enabled=true
+rpki.validator.rpki.object.cleanup.interval.ms=3600000
+rpki.validator.rpki.object.cleanup.grace.duration=P7D
 
-spring.mvc.message-codes-resolver.format=POSTFIX_ERROR_CODE
+rpki.validator.validation.run.cleanup.interval.ms=3600000
+rpki.validator.validation.run.cleanup.grace.duration=PT6H

--- a/rpki-validator/src/main/resources/packaging/centos7/etc/rpki-validator-3/application.properties
+++ b/rpki-validator/src/main/resources/packaging/centos7/etc/rpki-validator-3/application.properties
@@ -37,76 +37,15 @@
 # We plan to include example config for such a proxy setup in future
 server.port=8080
 
-#
-# The following directive is used to set where the rpki-validatorkeeps its
-# database.
-#
-# Note that the database cannot be shared by multiple instances
-spring.datasource.url=jdbc:h2:file:/var/lib/rpki-validator-3/db/rpki-validator.h2
-
-#
-# The following directive is used to set where preconfigured TALs that ship with
-# the RPM can be found. This is only used when the rpki-validator-3 is first started.
-# If you wish to add (or remove) a TAL later, you will need to use the API for now.
-# A UI option may be added for this in future.
-rpki.validator.preconfigured.trust.anchors.directory=/var/lib/rpki-validator-3/preconfigured-tals
-
-#
-# The following directive is used to set where files retrieved from rsync based RPKI
-# repositories are kept.
-rpki.validator.rsync.local.storage.directory=/var/lib/rpki-validator-3/rsync
-
-
 ################
 # Use the following settings to change JVM parameters
 #
 # Change the initial and maximum memory for the JVM
 #
 # Notes:
-# - 1.5GB of memory is needed for the current size of the combined RPKI repositories
+# - 512 megabytes of memory is needed for the current size of the combined RPKI repositories
 # - You may want to raise this value if you see 'out of memory' errors in the log
 # - A higher maximum will allow the JVM to use more system memory and spend less time on
 #   garbage collection (slight speed improvements possible)
 jvm.memory.initial=512m       # -Xms jvm option -> initial memory claimed by the jvm
-jvm.memory.maximum=1536m      # -Xmx jvm option -> maximum memory for the jvm
-
-
-
-########################
-# There should be no need to modify any of the following directives
-
-endpoints.enabled=false
-endpoints.health.enabled=true
-
-spring.datasource.name=rpki
-
-spring.datasource.username=rpki
-spring.datasource.password=rpki
-
-spring.mvc.message-codes-resolver.format=POSTFIX_ERROR_CODE
-
-spring.jpa.hibernate.ddl-auto=validate
-spring.jpa.properties.hibernate.show_sql=false
-spring.jpa.properties.hibernate.use_sql_comments=true
-spring.jpa.properties.hibernate.format_sql=true
-
-logging.level.net.ripe.rpki.validator3=INFO
-logging.level.org.springframework.context.annotation=INFO
-
-
-# Interval between checking rsync repositories for updates. This
-# parameter is directly passed to [Duration#parse]
-# (https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-).
-# The default value is 10 minutes.
-rpki.validator.rsync.repository.download.interval=PT10M
-
-rpki.validator.rrdp.trust.all.tls.certificates=true
-
-rpki.validator.rpki.object.cleanup.interval.ms=3600000
-rpki.validator.rpki.object.cleanup.grace.duration=P7D
-
-rpki.validator.validation.run.cleanup.interval.ms=3600000
-rpki.validator.validation.run.cleanup.grace.duration=PT6H
-
-spring.jackson.date-format=yyyy-MM-dd hh:mm:ss
-
+jvm.memory.maximum=512m       # -Xmx jvm option -> maximum memory for the jvm

--- a/rpki-validator/src/main/resources/packaging/centos7/usr/bin/rpki-validator-3.sh
+++ b/rpki-validator/src/main/resources/packaging/centos7/usr/bin/rpki-validator-3.sh
@@ -34,14 +34,15 @@ cd ${EXECUTION_DIR}
 
 JAVA_CMD="/usr/bin/java"
 APP_NAME="rpki-validator-3"
-CONFIG_FILE="/etc/${APP_NAME}/application.properties"
+CONFIG_DIR="/etc/${APP_NAME}"
+CONFIG_FILE="${CONFIG_DIR}/application.properties"
 JAR="/usr/lib/${APP_NAME}.jar"
 
 function parse_config_line {
-    local CONFIG_KEY=$1
-    local VALUE=`grep "^$CONFIG_KEY" $CONFIG_FILE | sed 's/#.*//g' | awk -F "=" '{ print $2 }'`
+    local CONFIG_KEY="$1"
+    local VALUE=`grep "^$CONFIG_KEY" "$CONFIG_FILE" | sed 's/#.*//g' | awk -F "=" '{ print $2 }'`
 
-    if [ -z $VALUE ]; then
+    if [ -z "$VALUE" ]; then
         error_exit "Cannot find value for: $CONFIG_KEY in config-file: $CONFIG_FILE"
     fi
     eval "$2=$VALUE"
@@ -52,4 +53,4 @@ parse_config_line "jvm.memory.maximum" JVM_XMX
 
 MEM_OPTIONS="-Xms$JVM_XMS -Xmx$JVM_XMX"
 
-${JAVA_CMD} ${MEM_OPTIONS} -Dapp.name="${APP_NAME}" -Dspring.config.location="file:${CONFIG_FILE}" -jar "${JAR}"
+exec ${JAVA_CMD} ${MEM_OPTIONS} -Dspring.config.location="classpath:/application.properties,file:${CONFIG_DIR}/application-defaults.properties,file:${CONFIG_FILE}" -jar "${JAR}"


### PR DESCRIPTION
Internal properties are configured in the
classpath:/application.properties file. Default properties are
specified in /etc/`app`/application-defaults.properties. They can be
overriden in /etc/`app`/application.properties.

The RPM still specifies /etc/`app`/application-defaults.properties as
a configuration file, which may be a problem when the
user (accidentally) modifies this file.