### PR TITLE
Store encoded RPKI objects in separate place

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/rpkiobjects/RpkiObjectController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/rpkiobjects/RpkiObjectController.java
@@ -51,6 +51,7 @@ import net.ripe.rpki.validator3.api.Api;
 import net.ripe.rpki.validator3.api.ApiResponse;
 import net.ripe.rpki.validator3.domain.CertificateTreeValidationRun;
 import net.ripe.rpki.validator3.domain.RpkiObject;
+import net.ripe.rpki.validator3.domain.RpkiObjects;
 import net.ripe.rpki.validator3.domain.ValidationCheck;
 import net.ripe.rpki.validator3.domain.ValidationRuns;
 import net.ripe.rpki.validator3.util.Hex;
@@ -84,12 +85,11 @@ import java.util.stream.StreamSupport;
 @Slf4j
 public class RpkiObjectController {
 
-    private final ValidationRuns validationRuns;
+    @Autowired
+    private RpkiObjects rpkiObjects;
 
     @Autowired
-    public RpkiObjectController(final ValidationRuns validationRuns) {
-        this.validationRuns = validationRuns;
-    }
+    private ValidationRuns validationRuns;
 
     @GetMapping(path = "/")
     public ResponseEntity<ApiResponse<Stream<RpkiObj>>> all() {
@@ -148,10 +148,7 @@ public class RpkiObjectController {
                                                                          final Optional<ValidationResult> validationResult,
                                                                          final Class<T> clazz,
                                                                          final Function<T, RpkiObj> create) {
-        Optional<T> maybeCert = validationResult.flatMap(vr -> rpkiObject.get(clazz, vr));
-        if (!maybeCert.isPresent()) {
-            maybeCert = rpkiObject.get(clazz, location(rpkiObject));
-        }
+        Optional<T> maybeCert = validationResult.flatMap(vr -> rpkiObjects.findCertificateRepositoryObject(rpkiObject.getId(), clazz, vr));
         if (maybeCert.isPresent()) {
             return create.apply(maybeCert.get());
         }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/EncodedRpkiObject.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/EncodedRpkiObject.java
@@ -1,0 +1,105 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.rpki.validator3.domain;
+
+import lombok.Getter;
+import net.ripe.rpki.commons.crypto.CertificateRepositoryObject;
+import net.ripe.rpki.commons.crypto.util.CertificateRepositoryObjectFactory;
+import net.ripe.rpki.commons.validation.ValidationResult;
+import net.ripe.rpki.validator3.util.Sha256;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static net.ripe.rpki.commons.validation.ValidationString.VALIDATOR_RPKI_OBJECT_HASH_MATCHES;
+
+@Entity
+public class EncodedRpkiObject extends AbstractEntity {
+
+    @OneToOne(optional = false)
+    @NotNull
+    private RpkiObject rpkiObject;
+
+    @Basic
+    @Getter
+    @NotNull
+    @NotEmpty
+    @Size(max = RpkiObject.MAX_SIZE)
+    private byte[] encoded;
+
+    protected EncodedRpkiObject() {
+    }
+
+    public EncodedRpkiObject(byte[] encoded) {
+        this.encoded = encoded;
+    }
+
+    public EncodedRpkiObject(RpkiObject rpkiObject, byte[] encoded) {
+        this.rpkiObject = rpkiObject;
+        this.encoded = encoded;
+    }
+
+    public <T extends CertificateRepositoryObject> Optional<T> get(Class<T> clazz, ValidationResult validationResult) {
+        ValidationResult temporary = ValidationResult.withLocation(validationResult.getCurrentLocation());
+        try {
+            return get(clazz, validationResult.getCurrentLocation().getName());
+        } finally {
+            validationResult.addAll(temporary);
+        }
+    }
+
+    public <T extends CertificateRepositoryObject> Optional<T> get(final Class<T> clazz, final String location) {
+        ValidationResult temporary = ValidationResult.withLocation(location);
+
+        ValidationResult ignored = ValidationResult.withLocation(location);
+        CertificateRepositoryObject candidate = CertificateRepositoryObjectFactory.createCertificateRepositoryObject(
+            encoded,
+            ignored // Ignore any parse errors, as all stored objects must be parsable
+        );
+
+        temporary.rejectIfNull(candidate, "rpki.object.parsable");
+        if (temporary.hasFailureForCurrentLocation()) {
+            return Optional.empty();
+        }
+
+        temporary.rejectIfFalse(clazz.isInstance(candidate), "rpki.object.type.matches", clazz.getSimpleName(), candidate.getClass().getSimpleName());
+        if (temporary.hasFailureForCurrentLocation()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(clazz.cast(candidate));
+    }
+}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjects.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjects.java
@@ -29,7 +29,9 @@
  */
 package net.ripe.rpki.validator3.domain;
 
+import net.ripe.rpki.commons.crypto.CertificateRepositoryObject;
 import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
+import net.ripe.rpki.commons.validation.ValidationResult;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.persistence.LockModeType;
@@ -48,6 +50,8 @@ public interface RpkiObjects {
     void merge(RpkiObject object);
     
     RpkiObject get(long id);
+
+    <T extends CertificateRepositoryObject> Optional<T> findCertificateRepositoryObject(long rpkiObjectId, Class<T> clazz, ValidationResult validationResult);
 
     Optional<RpkiObject> findBySha256(byte[] sha256);
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ValidatedRpkiObjects.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ValidatedRpkiObjects.java
@@ -38,6 +38,7 @@ import net.ripe.ipresource.Asn;
 import net.ripe.ipresource.IpRange;
 import net.ripe.rpki.commons.crypto.x509cert.X509CertificateUtil;
 import net.ripe.rpki.commons.crypto.x509cert.X509RouterCertificate;
+import net.ripe.rpki.commons.validation.ValidationResult;
 import net.ripe.rpki.validator3.api.Paging;
 import net.ripe.rpki.validator3.api.SearchTerm;
 import net.ripe.rpki.validator3.api.Sorting;
@@ -201,7 +202,7 @@ public class ValidatedRpkiObjects {
         rpkiObjects
             .stream()
             .filter(object -> object.getType() == RpkiObject.Type.ROUTER_CER)
-            .map(object -> object.get(X509RouterCertificate.class, "temporary"))
+            .map(object -> this.rpkiObjects.findCertificateRepositoryObject(object.getId(), X509RouterCertificate.class, ValidationResult.withLocation("temporary")))
             .filter(Optional::isPresent).map(Optional::get)
             .forEach(certificate -> {
                     final ImmutableList<String> asns = ImmutableList.copyOf(X509CertificateUtil.getAsns(certificate.getCertificate()));

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/cleanup/RpkiObjectCleanupService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/cleanup/RpkiObjectCleanupService.java
@@ -32,6 +32,7 @@ package net.ripe.rpki.validator3.domain.cleanup;
 import lombok.extern.slf4j.Slf4j;
 import net.ripe.rpki.commons.crypto.cms.manifest.ManifestCms;
 import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificate;
+import net.ripe.rpki.commons.validation.ValidationResult;
 import net.ripe.rpki.validator3.domain.RpkiObject;
 import net.ripe.rpki.validator3.domain.RpkiObjects;
 import net.ripe.rpki.validator3.domain.TrustAnchor;
@@ -142,7 +143,7 @@ public class RpkiObjectCleanupService {
     }
 
     private void traceManifest(Instant now, String name, RpkiObject manifest) {
-        manifest.get(ManifestCms.class, name).ifPresent(manifestCms -> {
+        this.rpkiObjects.findCertificateRepositoryObject(manifest.getId(), ManifestCms.class, ValidationResult.withLocation(name)).ifPresent(manifestCms -> {
             rpkiObjects.findObjectsInManifest(manifestCms, LockModeType.PESSIMISTIC_WRITE).forEach((entry, rpkiObject) -> {
                 markAndTraceObject(now, entry, rpkiObject);
             });
@@ -150,7 +151,7 @@ public class RpkiObjectCleanupService {
     }
 
     private void traceCaCertificate(Instant now, String name, RpkiObject caCertificate) {
-        caCertificate.get(X509ResourceCertificate.class, name).ifPresent(certificate -> {
+        this.rpkiObjects.findCertificateRepositoryObject(caCertificate.getId(), X509ResourceCertificate.class, ValidationResult.withLocation(name)).ifPresent(certificate -> {
             if (certificate.isCa() && certificate.getManifestUri() != null) {
                 traceCertificateAuthority(now, certificate);
             }

--- a/rpki-validator/src/main/resources/db/migration/V9__encoded_rpki_object.sql
+++ b/rpki-validator/src/main/resources/db/migration/V9__encoded_rpki_object.sql
@@ -1,0 +1,47 @@
+--
+-- The BSD License
+--
+-- Copyright (c) 2010-2018 RIPE NCC
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--   - Redistributions of source code must retain the above copyright notice,
+--     this list of conditions and the following disclaimer.
+--   - Redistributions in binary form must reproduce the above copyright notice,
+--     this list of conditions and the following disclaimer in the documentation
+--     and/or other materials provided with the distribution.
+--   - Neither the name of the RIPE NCC nor the names of its contributors may be
+--     used to endorse or promote products derived from this software without
+--     specific prior written permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+-- LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+-- CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+-- SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+-- INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+-- CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+-- ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+-- POSSIBILITY OF SUCH DAMAGE.
+--
+
+UPDATE rpki_repository SET last_downloaded_at = NULL, rrdp_session_id = NULL, rrdp_serial = NULL, status = 'PENDING';
+
+DELETE FROM rpki_object;
+
+CREATE TABLE encoded_rpki_object (
+    id BIGINT NOT NULL,
+    version INTEGER NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    rpki_object_id BIGINT,
+    encoded BINARY NOT NULL,
+    CONSTRAINT encoded_rpki_object__pk PRIMARY KEY (id),
+    CONSTRAINT encoded_rpki_object__rpki_object_id_unique UNIQUE (rpki_object_id ASC),
+    CONSTRAINT encoded_rpki_object__rpki_object_id_fk FOREIGN KEY (rpki_object_id) REFERENCES rpki_object (id) ON DELETE CASCADE
+);
+
+ALTER TABLE rpki_object DROP COLUMN encoded;


### PR DESCRIPTION
This way the encoded objects can be queried separately from the
Hibernate session and can be garbage collected separately.