### PR TITLE
Add healthcheck

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/bgp/BgpPreviewService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/bgp/BgpPreviewService.java
@@ -542,4 +542,8 @@ public class BgpPreviewService {
 
         return BgpValidity.of(origin.toString(), prefix.toString(), validity.toString(), validatingRoaStream);
     }
+
+    public List<BgpRisDump> getBgpDumps() {
+        return bgpRisDumps;
+    }
 }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/health/Health.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/health/Health.java
@@ -1,0 +1,10 @@
+package net.ripe.rpki.validator3.api.health;
+
+import java.util.Map;
+
+@lombok.Value(staticConstructor = "of")
+public class Health {
+    Map<String, Boolean> trustAnchorReady;
+    Map<String, Boolean> bgpDumpReady;
+    String databaseStatus;
+}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/health/Health.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/health/Health.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.api.health;
 
 import java.util.Map;

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/health/HealthController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/health/HealthController.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.api.health;
 
 import lombok.extern.slf4j.Slf4j;

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/health/HealthController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/health/HealthController.java
@@ -1,0 +1,66 @@
+package net.ripe.rpki.validator3.api.health;
+
+import lombok.extern.slf4j.Slf4j;
+import net.ripe.rpki.validator3.api.Api;
+import net.ripe.rpki.validator3.api.ApiResponse;
+import net.ripe.rpki.validator3.api.bgp.BgpPreviewService;
+import net.ripe.rpki.validator3.api.bgp.BgpRisDump;
+import net.ripe.rpki.validator3.api.trustanchors.TaStatus;
+import net.ripe.rpki.validator3.domain.TrustAnchors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.persistence.EntityManager;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping(path = "/api/healthcheck", produces = {Api.API_MIME_TYPE, "application/json"})
+@Slf4j
+public class HealthController {
+
+    @Autowired
+    private TrustAnchors trustAnchorRepository;
+
+    @Autowired
+    private BgpPreviewService bgpPreviewService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @GetMapping(path = "/")
+    public ResponseEntity<ApiResponse<Health>> health() {
+
+        final Map<String, Boolean> trustAnchorReady = trustAnchorRepository.getStatuses().stream().
+                collect(Collectors.toMap(
+                        TaStatus::getTaName,
+                        TaStatus::isCompletedValidation)
+                );
+
+        final Map<String, Boolean> bgpDumpReady = bgpPreviewService.getBgpDumps().stream().
+                collect(Collectors.toMap(
+                        BgpRisDump::getUrl,
+                        // the dump was updated not more than 20 minutes ago
+                        dmp -> dmp.getLastModified() != null && dmp.getLastModified().plusMinutes(20).isAfterNow()
+                ));
+
+        final String databaseStatus = databaseStatus();
+
+        return ResponseEntity.ok(ApiResponse.<Health>builder()
+                .data(Health.of(trustAnchorReady, bgpDumpReady, databaseStatus))
+                .build());
+    }
+
+
+    private String databaseStatus() {
+        try {
+            entityManager.createNativeQuery("SELECT 1").getSingleResult();
+            return "OK";
+        } catch (Exception e) {
+            return e.getMessage();
+        }
+    }
+}


### PR DESCRIPTION
It is some initial version of the healthcheck, required by the this issue
https://github.com/RIPE-NCC/rpki-validator-3/issues/41

We will, most probably, extend it, but for now it returns
- status of the DB -- if it's sane and can run a query
- statuses of the TAs -- if the first repository validation is completed for each of them
- statuses of BGP dumps -- if they are present and not too old.