### PR TITLE
Fix slow rsync init

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/adapter/jpa/JPARpkiRepositories.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/adapter/jpa/JPARpkiRepositories.java
@@ -93,7 +93,6 @@ public class JPARpkiRepositories extends JPARepository<RpkiRepository> implement
         if (result.getType() == RpkiRepository.Type.RSYNC) {
             RpkiRepository foundParent = findRsyncParentRepository(uri);
             if (foundParent != null) {
-                log.info("Found a parent {} to the repository {}", foundParent, uri);
                 result.setParentRepository(foundParent);
                 if (foundParent.isDownloaded()) {
                     result.setDownloaded(foundParent.getLastDownloadedAt());

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/adapter/jpa/JPARpkiRepositories.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/adapter/jpa/JPARpkiRepositories.java
@@ -93,6 +93,7 @@ public class JPARpkiRepositories extends JPARepository<RpkiRepository> implement
         if (result.getType() == RpkiRepository.Type.RSYNC) {
             RpkiRepository foundParent = findRsyncParentRepository(uri);
             if (foundParent != null) {
+                log.info("Found a parent {} to the repository {}", foundParent, uri);
                 result.setParentRepository(foundParent);
                 if (foundParent.isDownloaded()) {
                     result.setDownloaded(foundParent.getLastDownloadedAt());

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/TrustAnchorValidationJob.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/TrustAnchorValidationJob.java
@@ -43,7 +43,7 @@ public class TrustAnchorValidationJob implements Job {
     public static final String TRUST_ANCHOR_ID_KEY = "trustAnchorId";
 
     @Autowired
-    private TrustAnchorValidationService validationService;
+    private TrustAnchorValidationService trustAnchorValidationService;
 
     @Getter
     @Setter
@@ -51,7 +51,7 @@ public class TrustAnchorValidationJob implements Job {
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
-        validationService.validate(trustAnchorId);
+        trustAnchorValidationService.validate(trustAnchorId);
     }
 
     static JobDetail buildJob(TrustAnchor trustAnchor) {

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationService.java
@@ -273,7 +273,9 @@ public class CertificateTreeValidationService {
         return validatedObjects;
     }
 
-    private RpkiRepository registerRepository(TrustAnchor trustAnchor, Map<URI, RpkiRepository> registeredRepositories, CertificateRepositoryObjectValidationContext context) {
+    private RpkiRepository registerRepository(TrustAnchor trustAnchor,
+                                              Map<URI, RpkiRepository> registeredRepositories,
+                                              CertificateRepositoryObjectValidationContext context) {
         if (context.getRpkiNotifyURI() != null) {
             RpkiRepository rpkiRepository = registeredRepositories.computeIfAbsent(context.getRpkiNotifyURI(), (uri) -> rpkiRepositories.register(
                     trustAnchor,

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationService.java
@@ -128,6 +128,7 @@ public class TrustAnchorValidationService {
 
             validationRun.completeWith(validationResult);
             if (updated) {
+                // TODO Do this part outside of this specific transaction
                 final Set<TrustAnchor> affectedTrustAnchors = Sets.newHashSet(trustAnchor);
                 if (trustAnchor.getRsyncPrefetchUri() != null) {
                     rpkiRepositories.findByURI(trustAnchor.getRsyncPrefetchUri())


### PR DESCRIPTION
Fix for slow startup of rsync repositories, Afrinic and LACNIC in particular. If a TA has a prefetch.url, we synchronously prefetch the repository, before starting certificate tree validation.