### PR TITLE
To decide if certain TA is "ready" check

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/ignorefilters/IgnoreFiltersController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/ignorefilters/IgnoreFiltersController.java
@@ -124,15 +124,14 @@ public class IgnoreFiltersController {
     private IgnoreFilterDto toIgnoreFilter(IgnoreFilter f) {
         final IgnoreFiltersPredicate ignoreFiltersPredicate = new IgnoreFiltersPredicate(Stream.of(f));
         final List<ObjectController.RoaPrefix> affectedRoas = validatedRpkiObjects
-                .findCurrentlyValidatedRoaPrefixes(null, null, null)
-                .getObjects()
-                .filter(ignoreFiltersPredicate)
-                .map(prefix -> new ObjectController.RoaPrefix(
-                        String.valueOf(prefix.getAsn()),
-                        prefix.getPrefix().toString(),
-                        prefix.getEffectiveLength(),
-                        null)
-                ).collect(Collectors.toList());
+            .findCurrentlyValidatedRoaPrefixes(null, null, null)
+            .getObjects()
+            .filter(ignoreFiltersPredicate)
+            .map(prefix -> new ObjectController.RoaPrefix(
+                String.valueOf(prefix.getAsn()),
+                prefix.getPrefix().toString(),
+                prefix.getEffectiveLength())
+            ).collect(Collectors.toList());
         return new IgnoreFilterDto(f, affectedRoas);
     }
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ObjectController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ObjectController.java
@@ -41,12 +41,15 @@ import net.ripe.rpki.validator3.api.roaprefixassertions.RoaPrefixAssertionsServi
 import net.ripe.rpki.validator3.api.trustanchors.TrustAnchorResource;
 import net.ripe.rpki.validator3.domain.IgnoreFiltersPredicate;
 import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
-import net.ripe.rpki.validator3.storage.data.TrustAnchor;
 import net.ripe.rpki.validator3.storage.Storage;
+import net.ripe.rpki.validator3.storage.data.RpkiRepository;
+import net.ripe.rpki.validator3.storage.data.TrustAnchor;
+import net.ripe.rpki.validator3.storage.stores.RpkiRepositories;
 import net.ripe.rpki.validator3.storage.stores.Settings;
 import net.ripe.rpki.validator3.storage.stores.TrustAnchors;
+import net.ripe.rpki.validator3.util.Time;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.Links;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -72,6 +75,9 @@ public class ObjectController {
     private TrustAnchors trustAnchors;
 
     @Autowired
+    private RpkiRepositories rpkiRepositories;
+
+    @Autowired
     private IgnoreFilterService ignoreFilters;
 
     @Autowired
@@ -91,31 +97,16 @@ public class ObjectController {
 
     @GetMapping(path = "/validated")
     public ResponseEntity<ApiResponse<ValidatedObjects>> list(Locale locale) {
-        final Map<Long, TrustAnchorResource> trustAnchorsById = storage.readTx(tx ->
-                trustAnchors.findAll(tx).stream()
-                        .collect(Collectors.toMap(
-                                ta -> ta.key().asLong(),
-                                ta -> TrustAnchorResource.of(ta, locale))
-                        ));
-        final Map<Long, Links> trustAnchorLinks = trustAnchorsById.entrySet().stream()
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        entry -> new Links(entry.getValue().getLinks().getLink("self").withRel(TrustAnchor.TYPE)))
-                );
+        final List<TrustAnchor> trustAnchorList = storage.readTx(tx -> trustAnchors.findAll(tx));
 
         final Stream<RoaPrefix> validatedPrefixes = validatedRpkiObjects
             .findCurrentlyValidatedRoaPrefixes(null, null, null)
             .getObjects()
             .filter(new IgnoreFiltersPredicate(ignoreFilters.all()).negate())
-            .map(prefix -> {
-                    Links links = trustAnchorLinks.get(prefix.getTrustAnchor().getId());
-                    return new RoaPrefix(
-                        String.valueOf(prefix.getAsn()),
-                        prefix.getPrefix().toString(),
-                        prefix.getEffectiveLength(),
-                        links
-                    );
-                }
+            .map(prefix -> new RoaPrefix(
+                String.valueOf(prefix.getAsn()),
+                prefix.getPrefix().toString(),
+                prefix.getEffectiveLength())
             );
 
         final Stream<RoaPrefix> assertions = roaPrefixAssertions
@@ -123,8 +114,7 @@ public class ObjectController {
             .map(assertion -> new RoaPrefix(
                 assertion.getAsn().toString(),
                 assertion.getPrefix().toString(),
-                assertion.getMaxPrefixLength() != null ? assertion.getMaxPrefixLength() : assertion.getPrefix().getPrefixLength(),
-                null
+                assertion.getMaxPrefixLength() != null ? assertion.getMaxPrefixLength() : assertion.getPrefix().getPrefixLength()
             ));
 
         final Stream<RoaPrefix> combinedPrefixes = Stream.concat(validatedPrefixes, assertions).distinct();
@@ -140,13 +130,24 @@ public class ObjectController {
 
         final Stream<RouterCertificate> combinedAssertions = Stream.concat(filteredRouterCertificates, bgpSecAssertions).distinct();
 
+        Pair<Boolean, Long> allDoneForTa = Time.timed(() -> storage.readTx(tx ->
+            trustAnchorList.stream().allMatch(ta -> {
+                final Map<RpkiRepository.Status, Long> statusLongMap = rpkiRepositories.countByStatus(tx, ta.key(), true);
+                final Long pendingRepoNumber = statusLongMap.get(RpkiRepository.Status.PENDING);
+                return ta.isInitialCertificateTreeValidationRunCompleted() && pendingRepoNumber == null || pendingRepoNumber == 0L;
+            })));
+
+        final List<TrustAnchorResource> trustAnchorResources = trustAnchorList.stream()
+            .map(ta -> TrustAnchorResource.of(ta, Locale.ROOT))
+            .collect(Collectors.toList());
+
         return ResponseEntity.ok(ApiResponse.<ValidatedObjects>builder()
-                .data(new ValidatedObjects(
-                        storage.readTx(settings::isInitialValidationRunCompleted),
-                        trustAnchorsById.values(),
-                        combinedPrefixes,
-                        combinedAssertions))
-                .build());
+            .data(new ValidatedObjects(
+                allDoneForTa.getKey(),
+                trustAnchorResources,
+                combinedPrefixes,
+                combinedAssertions))
+            .build());
     }
 
     @Value
@@ -166,7 +167,6 @@ public class ObjectController {
         private String asn;
         private String prefix;
         private int maxLength;
-        private Links links;
     }
 
     @Value

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ObjectController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ObjectController.java
@@ -134,7 +134,7 @@ public class ObjectController {
             trustAnchorList.stream().allMatch(ta -> {
                 final Map<RpkiRepository.Status, Long> statusLongMap = rpkiRepositories.countByStatus(tx, ta.key(), true);
                 final Long pendingRepoNumber = statusLongMap.get(RpkiRepository.Status.PENDING);
-                return ta.isInitialCertificateTreeValidationRunCompleted() && pendingRepoNumber == null || pendingRepoNumber == 0L;
+                return ta.isInitialCertificateTreeValidationRunCompleted() && (pendingRepoNumber == null || pendingRepoNumber == 0L);
             })));
 
         final List<TrustAnchorResource> trustAnchorResources = trustAnchorList.stream()

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ObjectController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ObjectController.java
@@ -46,10 +46,7 @@ import net.ripe.rpki.validator3.storage.Storage;
 import net.ripe.rpki.validator3.storage.data.RpkiRepository;
 import net.ripe.rpki.validator3.storage.data.TrustAnchor;
 import net.ripe.rpki.validator3.storage.stores.RpkiRepositories;
-import net.ripe.rpki.validator3.storage.stores.Settings;
 import net.ripe.rpki.validator3.storage.stores.TrustAnchors;
-import net.ripe.rpki.validator3.util.Time;
-import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -146,7 +143,7 @@ public class ObjectController {
 
         return ResponseEntity.ok(ApiResponse.<ValidatedObjects>builder()
             .data(new ValidatedObjects(
-                allTasDoneInitialLoading && noPendingRepositories && trustAnchorState.allValidated(),
+                allTasDoneInitialLoading && noPendingRepositories && trustAnchorState.allTAsValidatedAfterRepositoryLoading(),
                 trustAnchorResources,
                 combinedPrefixes,
                 combinedAssertions))

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationService.java
@@ -98,6 +98,7 @@ public class CertificateTreeValidationService {
     private final TrustAnchors trustAnchors;
     private final Storage storage;
     private final ValidatedRpkiObjects validatedRpkiObjects;
+    private final TrustAnchorState trustAnchorState;
 
     @Autowired
     public CertificateTreeValidationService(RpkiObjects rpkiObjects,
@@ -107,7 +108,8 @@ public class CertificateTreeValidationService {
                                             ValidationRuns validationRuns,
                                             TrustAnchors trustAnchors,
                                             ValidatedRpkiObjects validatedRpkiObjects,
-                                            Storage storage) {
+                                            Storage storage,
+                                            TrustAnchorState trustAnchorState) {
         this.rpkiObjects = rpkiObjects;
         this.rpkiRepositories = rpkiRepositories;
         this.settings = settings;
@@ -116,6 +118,7 @@ public class CertificateTreeValidationService {
         this.trustAnchors = trustAnchors;
         this.validatedRpkiObjects = validatedRpkiObjects;
         this.storage = storage;
+        this.trustAnchorState = trustAnchorState;
     }
 
     public void validate(long trustAnchorId) {
@@ -193,6 +196,7 @@ public class CertificateTreeValidationService {
         } finally {
             validationRun.completeWith(validationResult);
             storage.writeTx0(tx -> validationRuns.update(tx, validationRun));
+            trustAnchorState.setValidatedAfterLastRepositoryUpdate(trustAnchor);
             long end = System.currentTimeMillis();
             log.info("Tree validation {} for {} in {}ms", validationRun.getStatus().toString().toLowerCase(), trustAnchor.getName(), (end - begin));
         }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorState.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorState.java
@@ -1,0 +1,46 @@
+package net.ripe.rpki.validator3.domain.validation;
+
+import lombok.extern.slf4j.Slf4j;
+import net.ripe.rpki.validator3.storage.data.TrustAnchor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * It is to keep track of the state of a TA. A TA transitions to the VALIDATED when
+ * and only when the data for it has been downloaded and the tree validation has been
+ * performed.
+ */
+@Component
+@Slf4j
+public class TrustAnchorState {
+    private enum State {
+        UNKNOWN,
+        VALIDATED
+    }
+
+    private final Map<String, State> states = new HashMap<>();
+
+    public boolean allValidated() {
+        synchronized (states) {
+            return states.values().stream().allMatch(s -> s.equals(State.VALIDATED));
+        }
+    }
+
+    public void setUnknown(TrustAnchor ta) {
+        setState(ta, State.UNKNOWN);
+    }
+
+    public void setValidatedAfterLastRepositoryUpdate(TrustAnchor ta) {
+        setState(ta, State.VALIDATED);
+    }
+
+    private void setState(TrustAnchor ta, State state) {
+        log.debug("Setting TA {} to {}", ta.getName(), state);
+        synchronized (states) {
+            states.put(ta.getName(), state);
+        }
+    }
+
+}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorState.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorState.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.domain.validation;
 
 import lombok.extern.slf4j.Slf4j;

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorState.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorState.java
@@ -22,7 +22,7 @@ public class TrustAnchorState {
 
     private final Map<String, State> states = new HashMap<>();
 
-    public boolean allValidated() {
+    public boolean allTAsValidatedAfterRepositoryLoading() {
         synchronized (states) {
             return states.values().stream().allMatch(s -> s.equals(State.VALIDATED));
         }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/ValidatedRpkiObjects.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/ValidatedRpkiObjects.java
@@ -124,8 +124,8 @@ public class ValidatedRpkiObjects {
                         roaPrefixesAndRouterCertificates.getRoaPrefixes().size(),
                         roaPrefixesAndRouterCertificates.getRouterCertificates().size()
                     );
-                    Locks.locked(dataLock.writeLock(), (Runnable) () ->
-                        validatedObjectsByTrustAnchor.put(trustAnchor.key().asLong(), roaPrefixesAndRouterCertificates));
+                    Locks.locked(dataLock.writeLock(),
+                        () -> validatedObjectsByTrustAnchor.put(trustAnchor.key().asLong(), roaPrefixesAndRouterCertificates));
                     notifyListeners();
                 }));
         log.info("Updated validated roas in {}ms", t);
@@ -142,10 +142,8 @@ public class ValidatedRpkiObjects {
 
     public void remove(TrustAnchor trustAnchor) {
         long trustAnchorId = trustAnchor.key().asLong();
-        Locks.locked(dataLock.writeLock(), () -> {
-            validatedObjectsByTrustAnchor.remove(trustAnchorId);
-            notifyListeners();
-        });
+        Locks.locked(dataLock.writeLock(), () -> validatedObjectsByTrustAnchor.remove(trustAnchorId));
+        notifyListeners();
     }
 
     public ValidatedObjects<RoaPrefix> findCurrentlyValidatedRoaPrefixes() {

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/ValidatedRpkiObjects.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/ValidatedRpkiObjects.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
-import net.ripe.ipresource.Asn;
 import net.ripe.ipresource.IpRange;
 import net.ripe.rpki.commons.crypto.x509cert.X509CertificateUtil;
 import net.ripe.rpki.commons.crypto.x509cert.X509RouterCertificate;
@@ -43,13 +42,12 @@ import net.ripe.rpki.validator3.api.Paging;
 import net.ripe.rpki.validator3.api.SearchTerm;
 import net.ripe.rpki.validator3.api.Sorting;
 import net.ripe.rpki.validator3.domain.RoaPrefixDefinition;
+import net.ripe.rpki.validator3.storage.Storage;
 import net.ripe.rpki.validator3.storage.Tx;
 import net.ripe.rpki.validator3.storage.data.Key;
 import net.ripe.rpki.validator3.storage.data.Ref;
 import net.ripe.rpki.validator3.storage.data.RpkiObject;
 import net.ripe.rpki.validator3.storage.data.TrustAnchor;
-import net.ripe.rpki.validator3.storage.data.validation.CertificateTreeValidationRun;
-import net.ripe.rpki.validator3.storage.Storage;
 import net.ripe.rpki.validator3.storage.stores.RpkiObjects;
 import net.ripe.rpki.validator3.storage.stores.TrustAnchors;
 import net.ripe.rpki.validator3.storage.stores.ValidationRuns;
@@ -96,47 +94,50 @@ public class ValidatedRpkiObjects {
 
     @PostConstruct
     private void initialize() {
-        Long t = Time.timed(() -> storage.readTx0(tx ->
-                validationRuns.findLatestSuccessful(tx, CertificateTreeValidationRun.class)
-                        .forEach(vr -> {
-                            final Set<Key> associatedPks = validationRuns.findAssociatedPks(tx, vr);
-                            updateByKey(tx, vr.getTrustAnchor(), associatedPks);
-                        })));
-        log.info("Initialised in {}ms", t);
+        Long t = Time.timed(() -> {
+            final List<TrustAnchor> trustAnchorList = storage.readTx(tx -> trustAnchors.findAll(tx));
+            trustAnchorList.parallelStream().forEach(ta ->
+                storage.readTx0(tx ->
+                    validationRuns.findLatestSuccessfulCaTreeValidationRun(tx, ta).ifPresent(vr -> {
+                        final Set<Key> associatedPks = validationRuns.findAssociatedPks(tx, vr);
+                        updateByKey(tx, vr.getTrustAnchor(), associatedPks);
+                    })));
+        });
+        log.info("Validated objects cache initialised in {}ms", t);
     }
 
     void updateByKey(Tx.Read tx, Ref<TrustAnchor> trustAnchor, Collection<Key> rpkiObjectsKeys) {
         Long t = Time.timed(() ->
-                trustAnchors.get(tx, trustAnchor.key())
-                        .map(ta -> {
-                            TrustAnchorData trustAnchorData = TrustAnchorData.of(trustAnchor.key().asLong(), ta.getName());
-                            Stream<RpkiObject> roaStream = streamByType(tx, rpkiObjectsKeys, RpkiObject.Type.ROA);
-                            Stream<RpkiObject> routerCertStream = streamByType(tx, rpkiObjectsKeys, RpkiObject.Type.ROUTER_CER);
-                            return RoaPrefixesAndRouterCertificates.of(
-                                    toRoaPrefixes(tx, trustAnchorData, roaStream),
-                                    toRouterCertificates(trustAnchorData, routerCertStream)
-                            );
-                        })
-                        .ifPresent(roaPrefixesAndRouterCertificates -> {
-                            log.info("updating validation objects cache for trust anchor {} with {} ROA prefixes and {} router certificates",
-                                    trustAnchor,
-                                    roaPrefixesAndRouterCertificates.getRoaPrefixes().size(),
-                                    roaPrefixesAndRouterCertificates.getRouterCertificates().size()
-                            );
-                            Locks.locked(dataLock.writeLock(), (Runnable)() ->
-                                    validatedObjectsByTrustAnchor.put(trustAnchor.key().asLong(), roaPrefixesAndRouterCertificates));
-                            notifyListeners();
-                        }));
+            trustAnchors.get(tx, trustAnchor.key())
+                .map(ta -> {
+                    TrustAnchorData trustAnchorData = TrustAnchorData.of(trustAnchor.key().asLong(), ta.getName());
+                    Stream<RpkiObject> roaStream = streamByType(tx, rpkiObjectsKeys, RpkiObject.Type.ROA);
+                    Stream<RpkiObject> routerCertStream = streamByType(tx, rpkiObjectsKeys, RpkiObject.Type.ROUTER_CER);
+                    return RoaPrefixesAndRouterCertificates.of(
+                        toRoaPrefixes(tx, trustAnchorData, roaStream),
+                        toRouterCertificates(trustAnchorData, routerCertStream)
+                    );
+                })
+                .ifPresent(roaPrefixesAndRouterCertificates -> {
+                    log.info("updating validation objects cache for trust anchor {} with {} ROA prefixes and {} router certificates",
+                        trustAnchor,
+                        roaPrefixesAndRouterCertificates.getRoaPrefixes().size(),
+                        roaPrefixesAndRouterCertificates.getRouterCertificates().size()
+                    );
+                    Locks.locked(dataLock.writeLock(), (Runnable) () ->
+                        validatedObjectsByTrustAnchor.put(trustAnchor.key().asLong(), roaPrefixesAndRouterCertificates));
+                    notifyListeners();
+                }));
         log.info("Updated validated roas in {}ms", t);
     }
 
     private Stream<RpkiObject> streamByType(Tx.Read tx, Collection<Key> rpkiObjectsKeys, RpkiObject.Type type) {
         final Set<Key> byType = rpkiObjects.getPkByType(tx, type);
         return rpkiObjectsKeys.stream()
-                .filter(byType::contains)
-                .map(k -> rpkiObjects.get(tx, k))
-                .filter(Optional::isPresent)
-                .map(Optional::get);
+            .filter(byType::contains)
+            .map(k -> rpkiObjects.get(tx, k))
+            .filter(Optional::isPresent)
+            .map(Optional::get);
     }
 
     public void remove(TrustAnchor trustAnchor) {
@@ -162,18 +163,18 @@ public class ValidatedRpkiObjects {
         Sorting finalSorting = sorting;
         Paging finalPaging = paging;
         return Locks.locked(dataLock.readLock(), () ->
-                ValidatedObjects.of(
-                        countRoaPrefixes(searchTerm),
-                        findRoaPrefixes(searchTerm, finalSorting, finalPaging)
-                ));
+            ValidatedObjects.of(
+                countRoaPrefixes(searchTerm),
+                findRoaPrefixes(searchTerm, finalSorting, finalPaging)
+            ));
     }
 
     public ValidatedObjects<RouterCertificate> findCurrentlyValidatedRouterCertificates() {
         return Locks.locked(dataLock.readLock(), () ->
-                ValidatedObjects.of(
-                        countRouterCertificates(),
-                        findRouterCertificates()
-                ));
+            ValidatedObjects.of(
+                countRouterCertificates(),
+                findRouterCertificates()
+            ));
     }
 
     public void addListener(Consumer<Collection<RoaPrefixesAndRouterCertificates>> listener) {
@@ -267,7 +268,7 @@ public class ValidatedRpkiObjects {
 
     private ImmutableList<RoaPrefixesAndRouterCertificates> validatedObjects() {
         return Locks.locked(dataLock.readLock(), () ->
-                ImmutableList.copyOf(validatedObjectsByTrustAnchor.values()));
+            ImmutableList.copyOf(validatedObjectsByTrustAnchor.values()));
     }
 
     private int countRouterCertificates() {
@@ -282,9 +283,9 @@ public class ValidatedRpkiObjects {
 
     private long countRoaPrefixes(SearchTerm searchTerm) {
         return validatedObjects().stream()
-                .flatMap(x -> x.getRoaPrefixes().stream())
-                .filter(prefix -> searchTerm == null || searchTerm.test(prefix))
-                .count();
+            .flatMap(x -> x.getRoaPrefixes().stream())
+            .filter(prefix -> searchTerm == null || searchTerm.test(prefix))
+            .count();
     }
 
     private Stream<RoaPrefix> findRoaPrefixes(SearchTerm searchTerm, Sorting sorting, Paging paging) {
@@ -299,6 +300,6 @@ public class ValidatedRpkiObjects {
 
     private void notifyListeners() {
         Locks.locked(dataLock.readLock(), () ->
-                listeners.forEach(listener -> listener.accept(validatedObjectsByTrustAnchor.values())));
+            listeners.forEach(listener -> listener.accept(validatedObjectsByTrustAnchor.values())));
     }
 }


### PR DESCRIPTION
This is to address the issue https://github.com/RIPE-NCC/rpki-validator-3/issues/124

We decide that "/api/objects/validated" should return "ready: true" only if for every TA
- if initial validation run has completed (behaviour before)
- if there're no repositories with status PENDING, related to this TA.

Also, remove "links" attribute from ROAs returned by this end-point, nobody cares about them.