### PR TITLE
Add http status code as prometheus metrics

### DIFF
--- a/rpki-rtr-server/pom.xml
+++ b/rpki-rtr-server/pom.xml
@@ -30,7 +30,6 @@
         <netty.version>4.1.19.Final</netty.version>
 
         <maven.build.timestamp.format>yyyy.MM.dd'.'HH.mm.ss</maven.build.timestamp.format>
-        <jetty-http2-client.version>9.4.11.v20180605</jetty-http2-client.version>
     </properties>
 
     <dependencies>

--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/RtrCache.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/RtrCache.java
@@ -78,16 +78,16 @@ public class RtrCache {
         reset();
 
         // Init metrics
-        Gauge.builder("validated_objects_count", () -> this.data.size())
+        Gauge.builder("validated.objects.count", () -> this.data.size())
             .description("Number of validated objects")
             .register(registry);
-        Gauge.builder("validated_objects_ready", () -> this.ready ? 1 : 0)
+        Gauge.builder("validated.objects.ready", () -> this.ready ? 1 : 0)
             .description("Status of the cache")
             .register(registry);
-        Gauge.builder("validated_objects_session_id", () -> this.sessionId)
+        Gauge.builder("validated.objects.session.id", () -> this.sessionId)
             .description("Session id of the cache")
             .register(registry);
-        Gauge.builder("validated_objects_serial", () -> this.getSerialNumber().getValue())
+        Gauge.builder("validated.objects.serial", () -> this.getSerialNumber().getValue())
             .description("Serial of the cache")
             .register(registry);
     }

--- a/rpki-validator/Changelog.txt
+++ b/rpki-validator/Changelog.txt
@@ -1,3 +1,6 @@
+* Mon Mar 16 2020 Ties de Kock <tdekock@ripe.net> - 3.1
+- Added prometheus metrics for http responses
+
 * Thu Mar 5 2020 Ties de Kock <tdekock@ripe.net> - 3.1
 - Updated spring boot to 2.2.5.
 - Add prometheus endpoint at /metrics.

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/HttpClientMetricsService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/HttpClientMetricsService.java
@@ -1,0 +1,76 @@
+package net.ripe.rpki.validator3.domain.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.extern.slf4j.Slf4j;
+import net.ripe.rpki.validator3.util.Http;
+import org.jooq.lambda.tuple.Tuple2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.EOFException;
+import java.net.URI;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Keep metrics for an URL and a HTTP status code <i>or</i> a string describing the error (e.g. "handshake_failure").
+ */
+@Slf4j
+@Service
+public class HttpClientMetricsService {
+    @Autowired
+    private MeterRegistry registry;
+
+    private ConcurrentHashMap<Tuple2<String, String>, HttpStatusMetric> httpMetrics = new ConcurrentHashMap<>();
+
+    public void update(String uri, String statusDescription, long durationMs) {
+        final String relativeURL = URI.create(uri).resolve("/").toString();
+        httpMetrics
+            .computeIfAbsent(new Tuple2<>(relativeURL, statusDescription), key -> new HttpStatusMetric(registry, relativeURL, statusDescription))
+            .update(durationMs);
+    }
+
+    /**
+     * Unwrap an exception to get a more meaningful status to aggregate under in the metrics.
+     * @param cause Throwable to unwrap
+     * @return string description
+     */
+
+    public static String unwrapExceptionString(Throwable cause) {
+        // Unwrap the failure and return message
+        if (cause instanceof Http.Failure) {
+            final Throwable rootCause = cause.getCause();
+            if (rootCause instanceof EOFException) {
+                return rootCause.getClass().getName();
+            }
+            return rootCause.toString();
+        } else if (cause instanceof Http.HttpStatusException) {
+            return String.valueOf(((Http.HttpStatusException)cause).getCode());
+        }
+        return "exception";
+    }
+
+    public static class HttpStatusMetric {
+        public final Counter responseStatusCounter;
+        public final Timer responseTiming;
+
+        public HttpStatusMetric(final MeterRegistry registry, final String uri, final String statusDescription) {
+            this.responseStatusCounter = Counter.builder("http.response.status")
+                    .description("HTTP request result (per server, per status)")
+                    .tag("url", uri)
+                    .tag("status", statusDescription)
+                    .register(registry);
+            this.responseTiming = Timer.builder("http.response.timing")
+                    .tag("url", uri)
+                    .publishPercentiles(0.5, 0.95, 0.99)
+                    .register(registry);
+        }
+
+        public void update(long durationMs) {
+            responseStatusCounter.increment();
+            responseTiming.record(durationMs, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/TrustAnchorMetricsService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/TrustAnchorMetricsService.java
@@ -60,10 +60,7 @@ public class TrustAnchorMetricsService {
     @Autowired
     private ValidationRuns validationRuns;
 
-    /**
-     * Creating multiple counters for the same trust anchor has no negative side-effects.
-     */
-    private ConcurrentHashMap<String, CertificateTreeValidationMetrics> cetrificateTreeValidationMetrics = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String, CertificateTreeValidationMetrics> certificateTreeValidationMetrics = new ConcurrentHashMap<>();
 
     public void update(TrustAnchor ta, CertificateTreeValidationRun vr, long durationMs) {
         final String uri = ta.getLocations().size() > 0 ? ta.getLocations().get(0) : null;
@@ -72,7 +69,7 @@ public class TrustAnchorMetricsService {
             return;
         }
 
-        cetrificateTreeValidationMetrics
+        certificateTreeValidationMetrics
                 .computeIfAbsent(uri, key -> new CertificateTreeValidationMetrics(ta))
                 .update(vr, durationMs);
     }
@@ -101,40 +98,40 @@ public class TrustAnchorMetricsService {
 
             this.rsyncPrefetchUri = trustAnchor.getLocations().get(0);
 
-            this.validationRunDuration = Timer.builder("validation_run_duration")
+            this.validationRunDuration = Timer.builder("validation.run.duration")
                     .description("Duration for the validation of the certificates descendant from this trust anchor.")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);
 
-            this.validationRunSuccessCount = Counter.builder("validation_run_count")
+            this.validationRunSuccessCount = Counter.builder("validation.run.count")
                     .description("Number of validation runs for the tree of certificates for this trust anchor.")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .tag("succeeded", "true")
                     .register(registry);
-            this.validationRunFailedCount = Counter.builder("validation_run_count")
+            this.validationRunFailedCount = Counter.builder("validation.run.count")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .tag("succeeded", "false")
                     .register(registry);
 
-            Gauge.builder("validation_results", objectCount::get)
+            Gauge.builder("validation.results", objectCount::get)
                     .description("Status of the objects under this trust anchor (identical to numbers on front page of web interface)")
                     .tag("status", "total")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);
 
-            Gauge.builder("validation_results", errorCount::get)
+            Gauge.builder("validation.results", errorCount::get)
                     .description("Status of the objects under this trust anchor (identical to numbers on front page of web interface)")
                     .tag("status", "error")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);
 
-            Gauge.builder("validation_results", warningCount::get)
+            Gauge.builder("validation.results", warningCount::get)
                     .description("Status of the objects under this trust anchor (identical to numbers on front page of web interface)")
                     .tag("status", "warning")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);
 
-            Gauge.builder("last_validation_run", lastSuccessfulValidationRunTime::get)
+            Gauge.builder("last.validation.run", lastSuccessfulValidationRunTime::get)
                     .description("Timestamp (in seconds) of the last successful validation run.")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);


### PR DESCRIPTION
Metrics for HTTP status codes (and error messages). Example metrics:
```
# HELP http_response_status_total HTTP request result (per server, per status)
# TYPE http_response_status_total counter
http_response_status_total{status="200",url="https://rrdp.apnic.net/",} 1.0
http_response_status_total{status="200",url="https://www.ris.ripe.net/",} 2.0
http_response_status_total{status="javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure",url="https://rrdp.ripe.net/",} 1.0
```

This should help me debug the amount of SSLHandshakeExceptions…