### PR TITLE
Unwrap sub-type of exception first

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/bgp/BgpRisDownloader.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/bgp/BgpRisDownloader.java
@@ -79,7 +79,7 @@ public class BgpRisDownloader {
     }
 
     @PreDestroy
-    public void preDestory() throws Exception {
+    public void preDestroy() throws Exception {
         httpClient.stop();
     }
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/HttpClientMetricsService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/HttpClientMetricsService.java
@@ -83,7 +83,7 @@ public class HttpClientMetricsService {
                 return rootCause.toString();
             }
         }
-        return cause.toString();
+        return cause.getClass().getName();
     }
 
     public static class HttpStatusMetric {

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/HttpClientMetricsService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/HttpClientMetricsService.java
@@ -82,9 +82,8 @@ public class HttpClientMetricsService {
                 }
                 return rootCause.toString();
             }
-            return cause.toString();
         }
-        return "exception";
+        return cause.toString();
     }
 
     public static class HttpStatusMetric {

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/HttpClientMetricsService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/HttpClientMetricsService.java
@@ -69,17 +69,20 @@ public class HttpClientMetricsService {
      * @param cause Throwable to unwrap
      * @return string description
      */
-
     public static String unwrapExceptionString(Throwable cause) {
-        // Unwrap the failure and return message
-        if (cause instanceof Http.Failure) {
-            final Throwable rootCause = cause.getCause();
-            if (rootCause instanceof EOFException) {
-                return rootCause.getClass().getName();
-            }
-            return rootCause.toString();
-        } else if (cause instanceof Http.HttpStatusException) {
+        // HttpStatusException is a sub-type of Http.Failure: check it first.
+        if (cause instanceof Http.HttpStatusException) {
             return String.valueOf(((Http.HttpStatusException)cause).getCode());
+        } else if (cause instanceof Http.Failure) {
+            final Throwable rootCause = cause.getCause();
+            if (rootCause != null) {
+                if (rootCause instanceof EOFException) {
+                    // message is unique for each exception, group them by name
+                    return rootCause.getClass().getName();
+                }
+                return rootCause.toString();
+            }
+            return cause.toString();
         }
         return "exception";
     }


### PR DESCRIPTION
Cause was empty for `HttpStatusException`. Now we handle `Http.Failure`'s without a cause properly.

This may cause some unique log messages (and transitively unique metrics in prometheus). I'll keep an eye on that.