### PR TITLE
Raise the RIS visibility threshold to ten peers

### DIFF
--- a/rpki-validator/src/main/resources/application.properties
+++ b/rpki-validator/src/main/resources/application.properties
@@ -48,7 +48,7 @@ rpki.validator.preconfigured.trust.anchors.directory=./src/main/resources/packag
 rpki.validator.rsync.local.storage.directory=/tmp/rpki-validator-3
 
 rpki.validator.bgp.ris.dump.urls=https://www.ris.ripe.net/dumps/riswhoisdump.IPv4.gz,https://www.ris.ripe.net/dumps/riswhoisdump.IPv6.gz
-rpki.validator.bgp.ris.visibility.threshold=5
+rpki.validator.bgp.ris.visibility.threshold=10
 
 # Interval between checking rsync repositories for updates. This
 # parameter is directly passed to [Duration#parse]

--- a/rpki-validator/src/main/resources/packaging/generic/conf/application-defaults.properties
+++ b/rpki-validator/src/main/resources/packaging/generic/conf/application-defaults.properties
@@ -70,7 +70,7 @@ logging.level.org.quartz=OFF
 rpki.validator.bgp.ris.dump.urls=https://www.ris.ripe.net/dumps/riswhoisdump.IPv4.gz,https://www.ris.ripe.net/dumps/riswhoisdump.IPv6.gz
 
 # Minimum visibility of BGP RIS entries.
-rpki.validator.bgp.ris.visibility.threshold=5
+rpki.validator.bgp.ris.visibility.threshold=10
 
 # Interval between checking rsync repositories for updates. This
 # parameter is directly passed to [Duration#parse]


### PR DESCRIPTION
Changes the number of peers to be equal to the threshold used by ripestat.