### PR TITLE
Bump spring boot version for new Jackson version

### DIFF
--- a/rpki-parent/pom.xml
+++ b/rpki-parent/pom.xml
@@ -20,7 +20,8 @@
 
         <rpki-commons.version>1.8.0</rpki-commons.version>
 
-        <micrometer.version>1.3.5</micrometer.version>
+        <!-- Micrometer.version from spring boot -->
+
         <springfox.version>2.7.0</springfox.version>
         <build.version>3.1</build.version>
         <build.release>${maven.build.timestamp}</build.release>
@@ -29,7 +30,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.2.5.RELEASE</version>
+        <version>2.2.6.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
No security implications because Hikari is not on classpath and we do'nt deserialize polymorphic types (let alone polymorphic types with open bounds).

This update keeps a dark cockpit in whitesource.