### PR TITLE
Fix export-extended

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ExportsController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ExportsController.java
@@ -193,9 +193,9 @@ public class ExportsController {
                         assertion.getPrefix().toString(),
                         assertion.getMaxPrefixLength() != null ? assertion.getMaxPrefixLength() : assertion.getPrefix().getPrefixLength(),
                         "SLURM",
-                        "",
-                        "",
-                        ""
+                        null,
+                        null,
+                        null
                 ));
 
 

--- a/ui-validator/src/app/roas/export/export.component.ts
+++ b/ui-validator/src/app/roas/export/export.component.ts
@@ -8,7 +8,11 @@ import {Component, OnInit} from '@angular/core';
       <p>{{'Export.DESCRIPTION' | translate}}</p>
       <a href="api/export.csv" class="btn-primary">Get CSV</a>
       <a href="api/export.json" class="btn-primary" target="_blank">Get JSON</a>
-      <a href="api/export-extended.json" class="btn-primary" target="_blank">Get JSON (extended)</a>
+    </div>
+    <div class="pb-4">
+      <p>{{'Export.DESCRIPTION_EXTENDED' | translate}}</p>
+      <a href="api/export-extended.csv" class="btn-primary">Get CSV  </a> &nbsp;
+      <a href="api/export-extended.json" class="btn-primary" target="_blank">Get JSON </a>
     </div>
     `,
   styles: [`

--- a/ui-validator/src/assets/i18n/en.json
+++ b/ui-validator/src/assets/i18n/en.json
@@ -166,7 +166,8 @@
     "CLICK_LINK_TO_ANNOUNCEMENT": "Click link to see details about announcement"
   },
   "Export": {
-    "DESCRIPTION": "Here you are able to export the complete ROA data set for use in an existing BGP decision making workflow. The output will be in CSV or JSON format and consist of all validated ROAs, minus your ignore filter entries, plus your whitelist entries."
+    "DESCRIPTION": "Here you are able to export the complete ROA data set for use in an existing BGP decision making workflow. The output will be in CSV or JSON format and consist of all validated ROAs, minus your ignore filter entries, plus your whitelist entries.",
+    "DESCRIPTION_EXTENDED": "Export with additional validity and serial number information for ROAs."
   },
   "Slurm": {
     "SLURM": "Import / Export Filter and Whitelist Entries",


### PR DESCRIPTION
UI still expect export-extended backend to exist, while backend is renamed to roas-only.
I remember we renamed because we don't include SLURM on the extended.

Now this change revert backend API path, and include slurm on extended, without
additional info.

{
    "asn" : "12314",
    "prefix" : "192.168.0.0/24",
    "maxLength" : 24,
    "ta" : "SLURM",
    "notBefore" : "",
    "notAfter" : "",
    "serialNumber" : ""
  }