### PR TITLE
Bump xodus version to 1.3.232

### DIFF
--- a/rpki-validator/pom.xml
+++ b/rpki-validator/pom.xml
@@ -27,8 +27,8 @@
 
     <properties>
         <maven.build.timestamp.format>yyyy.MM.dd'.'HH.mm.ss</maven.build.timestamp.format>
-        <xodus.version>1.3.124</xodus.version>
-	    <jetty.version>9.4.21.v20190926</jetty.version>
+        <xodus.version>1.3.232</xodus.version>
+        <jetty.version>9.4.21.v20190926</jetty.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Plain bump to the latest xodus version.

From [the changelog](https://youtrack.jetbrains.com/releaseNotes?q=%23XD%20%23Resolved%20Fix%20versions:%201.3.232&title=1.3.232):
```
XD-768 — Performance degradation and OOM crash while sequentially process large transactions
```

There is also the new "soft-reference cache" [feature](https://youtrack.jetbrains.com/issue/XD-799) which would need configuration.