### PR TITLE
Fallback to rsync from https when trust anchor certificate can not be loaded

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/retrieval/TrustAnchorRetrievalService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/retrieval/TrustAnchorRetrievalService.java
@@ -106,7 +106,7 @@ public class TrustAnchorRetrievalService {
             log.debug("HTTP {} when fetching HTTPS trust anchor from {}", res.getStatus(), trustAnchorCertificateURI);
             statusDescription = String.valueOf(res.getStatus());
             if (res.getStatus() != 200) {
-                validationResult.error(ErrorCodes.TRUST_ANCHOR_FETCH, trustAnchorCertificateURI.toASCIIString(), String.format("HTTP %d - %s", res.getStatus(), res.getReason()));
+                validationResult.warn(ErrorCodes.TRUST_ANCHOR_FETCH, trustAnchorCertificateURI.toASCIIString(), String.format("HTTP %d - %s", res.getStatus(), res.getReason()));
                 return null;
             }
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/retrieval/TrustAnchorRetrievalService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/retrieval/TrustAnchorRetrievalService.java
@@ -90,7 +90,7 @@ public class TrustAnchorRetrievalService {
                 validationResult.error(ErrorCodes.TRUST_ANCHOR_FETCH, trustAnchorCertificateURI.toASCIIString(), "File support not explicitly enabled.");
                 return null;
             default:
-                validationResult.error(ErrorCodes.TRUST_ANCHOR_FETCH, trustAnchorCertificateURI.toASCIIString(), "Unsupported URI");
+                validationResult.warn(ErrorCodes.TRUST_ANCHOR_FETCH, trustAnchorCertificateURI.toASCIIString(), "Unsupported URI");
                 return null;
         }
     }
@@ -112,7 +112,7 @@ public class TrustAnchorRetrievalService {
 
             return res.getContent();
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            validationResult.error(ErrorCodes.TRUST_ANCHOR_FETCH, trustAnchorCertificateURI.toASCIIString(), e.getMessage());
+            validationResult.warn(ErrorCodes.TRUST_ANCHOR_FETCH, trustAnchorCertificateURI.toASCIIString(), e.getMessage());
             statusDescription = HttpClientMetricsService.unwrapExceptionString(e);
 
             log.error("Error while loading trust anchor certificate over https", e);
@@ -135,7 +135,7 @@ public class TrustAnchorRetrievalService {
         rsyncMetrics.update(trustAnchorCertificateURI, exitStatus, System.currentTimeMillis() - t0);
 
         if (exitStatus != 0) {
-            validationResult.error(ErrorCodes.RSYNC_FETCH, String.valueOf(exitStatus), ArrayUtils.toString(rsync.getErrorLines()));
+            validationResult.warn(ErrorCodes.RSYNC_FETCH, String.valueOf(exitStatus), ArrayUtils.toString(rsync.getErrorLines()));
             return null;
         } else {
             log.info("Downloaded certificate {} to {}", trustAnchorCertificateURI, targetFile);

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/TrustAnchor.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/TrustAnchor.java
@@ -104,8 +104,8 @@ public class TrustAnchor extends Base<TrustAnchor> {
 
     public List<URI> getLocationsByPreference() {
         return locations.stream()
-            .sorted(Comparator.naturalOrder())
             .map(URI::create)
+            .sorted(Comparator.comparing(URI::getScheme))
             .collect(Collectors.toList());
     }
 }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/TrustAnchor.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/TrustAnchor.java
@@ -41,8 +41,11 @@ import net.ripe.rpki.validator3.storage.Binary;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.net.URI;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @EqualsAndHashCode(callSuper = true)
 @Binary
@@ -97,5 +100,12 @@ public class TrustAnchor extends Base<TrustAnchor> {
 
     public void markInitialCertificateTreeValidationRunCompleted() {
         this.initialCertificateTreeValidationRunCompleted = true;
+    }
+
+    public List<URI> getLocationsByPreference() {
+        return locations.stream()
+            .sorted(Comparator.naturalOrder())
+            .map(URI::create)
+            .collect(Collectors.toList());
     }
 }

--- a/rpki-validator/src/main/resources/messages.properties
+++ b/rpki-validator/src/main/resources/messages.properties
@@ -63,8 +63,8 @@ rsync.fetch.warning=Rsync failed with exit status {0}: {1}
 rsync.fetch.passed=Rsync succeeded: {1}
 rsync.repository.io.error=Rsync repository I/O error: {0}
 
-trust.anchor.fetch.error=Trust anchor could not be loaded from {0} with error: {1}
-trust.anchor.fetch.warning=Trust anchor could not be loaded from {0} with warning: {1}
+trust.anchor.fetch.error=Trust anchor could not be loaded from {0}: {1}
+trust.anchor.fetch.warning=Trust anchor could not be loaded from {0}: {1}
 trust.acnhor.fetch.passed=Trust anchor loaded from {0}
 
 trust.anchor.signature.error=Trust anchor certificate {0} did not match public key signature {1}

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationServiceLocationTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationServiceLocationTest.java
@@ -1,0 +1,139 @@
+package net.ripe.rpki.validator3.domain.validation;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
+import lombok.Setter;
+import net.ripe.rpki.commons.crypto.x509cert.X509ResourceCertificate;
+import net.ripe.rpki.validator3.IntegrationTest;
+import net.ripe.rpki.validator3.domain.ErrorCodes;
+import net.ripe.rpki.validator3.domain.retrieval.TrustAnchorRetrievalService;
+import net.ripe.rpki.validator3.storage.data.TrustAnchor;
+import net.ripe.rpki.validator3.storage.data.validation.TrustAnchorValidationRun;
+import net.ripe.rpki.validator3.storage.data.validation.ValidationCheck;
+import net.ripe.rpki.validator3.storage.stores.TrustAnchors;
+import net.ripe.rpki.validator3.storage.stores.ValidationRuns;
+import net.ripe.rpki.validator3.storage.stores.impl.GenericStorageTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static net.ripe.rpki.validator3.domain.validation.TrustAnchorValidationServiceTest.createRipeNccTrustAnchor;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@IntegrationTest
+@Setter
+public class TrustAnchorValidationServiceLocationTest extends GenericStorageTest {
+    private static final String DUMMY_RSYNC_URI = "rsync://rpki.example.org/ta/ta.cer";
+    private static final String DUMMY_HTTPS_URI = "https://rpki.example.org/ta/ta.cer";
+
+    @MockBean
+    private TrustAnchorRetrievalService trustAnchorRetrievalService;
+
+    @Autowired
+    private TrustAnchorValidationService subject;
+
+    @Autowired
+    private TrustAnchors trustAnchors;
+
+    @Autowired
+    private ValidationRuns validationRuns;
+
+    @Test
+    public void testLocation_fallback_to_rsync() throws IOException {
+        given(trustAnchorRetrievalService.fetchTrustAnchorCertificate(eq(URI.create(DUMMY_HTTPS_URI)), any()))
+                .willReturn(null);
+        given(trustAnchorRetrievalService.fetchTrustAnchorCertificate(eq(URI.create(DUMMY_RSYNC_URI)), any()))
+                .willReturn(Resources.toByteArray(new ClassPathResource("ripe-ncc-ta.cer").getURL()));
+
+        InOrder inOrder = Mockito.inOrder(trustAnchorRetrievalService);
+
+        TrustAnchor ta = createRipeNccTrustAnchor();
+        ta.setLocations(ImmutableList.of(DUMMY_RSYNC_URI, DUMMY_HTTPS_URI));
+        wtx0(tx -> trustAnchors.add(tx, ta));
+
+        subject.validate(ta.key().asLong());
+
+        X509ResourceCertificate certificate = rtx(tx -> trustAnchors.get(tx, ta.key()).get().getCertificate());
+        assertThat(certificate).isNotNull();
+
+        Optional<TrustAnchorValidationRun> validationRun = rtx(tx -> validationRuns.findLatestCompletedForTrustAnchor(tx, ta));
+        assertThat(validationRun).isPresent();
+        assertThat(validationRun.get().isSucceeded()).isTrue();
+
+        // Do not validate validation result: Warnings/errors were not added because the relevant code was mocked.
+
+        then(trustAnchorRetrievalService).should(inOrder).fetchTrustAnchorCertificate(eq(URI.create(DUMMY_HTTPS_URI)), any());
+        then(trustAnchorRetrievalService).should(inOrder).fetchTrustAnchorCertificate(eq(URI.create(DUMMY_RSYNC_URI)), any());
+    }
+
+    @Test
+    public void testLocation_only_https_is_called_when_succeeds() throws IOException {
+        final byte[] cert = Resources.toByteArray(new ClassPathResource("ripe-ncc-ta.cer").getURL());
+
+        given(trustAnchorRetrievalService.fetchTrustAnchorCertificate(eq(URI.create(DUMMY_HTTPS_URI)), any()))
+                .willReturn(cert);
+        given(trustAnchorRetrievalService.fetchTrustAnchorCertificate(eq(URI.create(DUMMY_RSYNC_URI)), any()))
+                .willReturn(cert);
+
+        InOrder inOrder = Mockito.inOrder(trustAnchorRetrievalService);
+
+        TrustAnchor ta = createRipeNccTrustAnchor();
+        ta.setLocations(ImmutableList.of(DUMMY_RSYNC_URI, DUMMY_HTTPS_URI));
+        wtx0(tx -> trustAnchors.add(tx, ta));
+
+        subject.validate(ta.key().asLong());
+
+        X509ResourceCertificate certificate = rtx(tx -> trustAnchors.get(tx, ta.key()).get().getCertificate());
+        assertThat(certificate).isNotNull();
+
+        Optional<TrustAnchorValidationRun> validationRun = rtx(tx -> validationRuns.findLatestCompletedForTrustAnchor(tx, ta));
+        assertThat(validationRun).isPresent();
+        assertThat(validationRun.get().isSucceeded()).isTrue();
+
+        // Do not validate validation result: Warnings/errors were not added because the relevant code was mocked.
+
+        then(trustAnchorRetrievalService).should(inOrder).fetchTrustAnchorCertificate(eq(URI.create(DUMMY_HTTPS_URI)), any());
+        then(trustAnchorRetrievalService).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void testLocation_fails_when_all_locations_fail() throws IOException {
+        given(trustAnchorRetrievalService.fetchTrustAnchorCertificate(eq(URI.create(DUMMY_HTTPS_URI)), any()))
+                .willReturn(null);
+        given(trustAnchorRetrievalService.fetchTrustAnchorCertificate(eq(URI.create(DUMMY_RSYNC_URI)), any()))
+                .willReturn(null);
+
+        InOrder inOrder = Mockito.inOrder(trustAnchorRetrievalService);
+
+        TrustAnchor ta = createRipeNccTrustAnchor();
+        ta.setLocations(ImmutableList.of(DUMMY_RSYNC_URI, DUMMY_HTTPS_URI));
+        wtx0(tx -> trustAnchors.add(tx, ta));
+
+        subject.validate(ta.key().asLong());
+
+        X509ResourceCertificate certificate = rtx(tx -> trustAnchors.get(tx, ta.key()).get().getCertificate());
+        assertThat(certificate).isNull();
+
+        Optional<TrustAnchorValidationRun> validationRun = rtx(tx -> validationRuns.findLatestCompletedForTrustAnchor(tx, ta));
+        assertThat(validationRun).isPresent();
+        assertThat(validationRun.get().isFailed()).isTrue();
+
+        final List<ValidationCheck> validationChecks = validationRun.get().getValidationChecks();
+        assertThat(validationChecks).anyMatch(vc -> ErrorCodes.TRUST_ANCHOR_FETCH.equals(vc.getKey()) && ValidationCheck.Status.ERROR.equals(vc.getStatus()));
+
+        then(trustAnchorRetrievalService).should(inOrder).fetchTrustAnchorCertificate(eq(URI.create(DUMMY_HTTPS_URI)), any());
+        then(trustAnchorRetrievalService).should(inOrder).fetchTrustAnchorCertificate(eq(URI.create(DUMMY_RSYNC_URI)), any());
+    }
+}

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationServiceLocationTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationServiceLocationTest.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.domain.validation;
 
 import com.google.common.collect.ImmutableList;

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationServiceTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationServiceTest.java
@@ -109,8 +109,10 @@ public class TrustAnchorValidationServiceTest extends GenericStorageTest {
         assertThat(validationRun).isPresent();
 
         List<ValidationCheck> validationChecks = validationRun.get().getValidationChecks();
-        assertThat(validationChecks).hasSize(1);
-        assertThat(validationChecks.get(0).getKey()).isEqualTo(ErrorCodes.RSYNC_FETCH);
+        assertThat(validationChecks).hasSize(2);
+
+        assertThat(validationChecks).anyMatch(vc -> vc.getKey().equals(ErrorCodes.RSYNC_FETCH));
+        assertThat(validationChecks).anyMatch(vc -> vc.getKey().equals(ErrorCodes.TRUST_ANCHOR_FETCH));
     }
 
     @Test

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/data/TrustAnchorTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/data/TrustAnchorTest.java
@@ -1,0 +1,29 @@
+package net.ripe.rpki.validator3.storage.data;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TrustAnchorTest {
+    @Test
+    public void getLocationsByPreference_prefers_https_over_rsync() {
+        TrustAnchor ta = new TrustAnchor();
+        ta.setLocations(Lists.newArrayList("rsync://rpki.ripe.net/ta/ripe-ncc-ta.cer", "https://rpki.ripe.net/ta/ripe-ncc-ta.cer"));
+
+        assertThat(ta.getLocationsByPreference()).containsExactly(
+                URI.create("https://rpki.ripe.net/ta/ripe-ncc-ta.cer"),
+                URI.create("rsync://rpki.ripe.net/ta/ripe-ncc-ta.cer")
+        );
+    }
+
+    @Test
+    public void getLocationsByPreference_handles_empty() {
+        TrustAnchor ta = new TrustAnchor();
+        ta.setLocations(Lists.newArrayList());
+
+        assertThat(ta.getLocationsByPreference()).isEmpty();
+    }
+}

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/data/TrustAnchorTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/data/TrustAnchorTest.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.storage.data;
 
 import org.assertj.core.util.Lists;

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/data/TrustAnchorTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/data/TrustAnchorTest.java
@@ -49,6 +49,26 @@ public class TrustAnchorTest {
     }
 
     @Test
+    public void getLocationsByPreference_keeps_order_within_protocol() {
+        TrustAnchor ta = new TrustAnchor();
+        ta.setLocations(Lists.newArrayList("rsync://rpki.ripe.net/b/ripe-ncc-ta.cer", "rsync://rpki.ripe.net/a/ripe-ncc-ta.cer", "https://rpki.ripe.net/ta/ripe-ncc-ta.cer"));
+
+        assertThat(ta.getLocationsByPreference()).containsExactly(
+                URI.create("https://rpki.ripe.net/ta/ripe-ncc-ta.cer"),
+                URI.create("rsync://rpki.ripe.net/b/ripe-ncc-ta.cer"),
+                URI.create("rsync://rpki.ripe.net/a/ripe-ncc-ta.cer")
+        );
+
+        ta.setLocations(Lists.newArrayList("rsync://rpki.ripe.net/a/ripe-ncc-ta.cer", "https://rpki.ripe.net/ta/ripe-ncc-ta.cer", "rsync://rpki.ripe.net/b/ripe-ncc-ta.cer"));
+
+        assertThat(ta.getLocationsByPreference()).containsExactly(
+                URI.create("https://rpki.ripe.net/ta/ripe-ncc-ta.cer"),
+                URI.create("rsync://rpki.ripe.net/a/ripe-ncc-ta.cer"),
+                URI.create("rsync://rpki.ripe.net/b/ripe-ncc-ta.cer")
+        );
+    }
+
+    @Test
     public void getLocationsByPreference_handles_empty() {
         TrustAnchor ta = new TrustAnchor();
         ta.setLocations(Lists.newArrayList());

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/util/ValidateProvidedTrustAnchorTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/util/ValidateProvidedTrustAnchorTest.java
@@ -87,7 +87,6 @@ public class ValidateProvidedTrustAnchorTest {
         assertEquals(certificateHashes.size(), 1);
     }
 
-    @SneakyThrows(IOException.class)
     private byte[] readCertificateFromUri(URI uri) {
         ValidationResult res = ValidationResult.withLocation(uri);
 


### PR DESCRIPTION
Quick and slightly dirty implementation of fallback behaviour. Would like it if the implementation is slightly cleaner.