### PR TITLE
Use copy to add artifact to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM adoptopenjdk:11-jre-hotspot as intermediate
 
 ARG GENERIC_BUILD_ARCHIVE
 
-ADD ${GENERIC_BUILD_ARCHIVE} /tmp/
+COPY ${GENERIC_BUILD_ARCHIVE} /tmp/
 
 RUN mkdir -p /opt/rpki-validator-3 \
     && tar -zxf /tmp/$(basename $GENERIC_BUILD_ARCHIVE) -C /opt/rpki-validator-3/ --strip-components=1


### PR DESCRIPTION
Fixes the build in CI.

ADD with a path:
`artifacts/foo.tar.gz` -> `/tmp/artifacts/foo.tar.gz`
`basename artifacs/foo.tar.gz`: `foo.tar.gz`
ADD with a url:
`https://example.org/subdir/foo.tar.gz` -> `/tmp/foo.tar.gz`
`basename https://example.org/subdir/foo.tar.gz`: `foo.tar.gz`

COPY with a path (no url support):
`artifacts/foo.tar.gz` -> `/tmp/foo.tar.gz`

Decided to just use COPY again.