### PR TITLE
Rename prometheus metrics to follow best practices and track rtr connections

### DIFF
--- a/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/RtrCache.java
+++ b/rpki-rtr-server/src/main/java/net/ripe/rpki/rtr/domain/RtrCache.java
@@ -78,16 +78,16 @@ public class RtrCache {
         reset();
 
         // Init metrics
-        Gauge.builder("validated.objects.count", () -> this.data.size())
+        Gauge.builder("rtrserver.validated.objects.count", this.data::size)
             .description("Number of validated objects")
             .register(registry);
-        Gauge.builder("validated.objects.ready", () -> this.ready ? 1 : 0)
+        Gauge.builder("rtrserver.validated.objects.ready", () -> this.ready ? 1 : 0)
             .description("Status of the cache")
             .register(registry);
-        Gauge.builder("validated.objects.session.id", () -> this.sessionId)
+        Gauge.builder("rtrserver.validated.objects.session.id", () -> this.sessionId)
             .description("Session id of the cache")
             .register(registry);
-        Gauge.builder("validated.objects.serial", () -> this.getSerialNumber().getValue())
+        Gauge.builder("rtrserver.validated.objects.serial", () -> this.getSerialNumber().getValue())
             .description("Serial of the cache")
             .register(registry);
     }

--- a/rpki-rtr-server/src/test/java/net/ripe/rpki/rtr/RtrServerTest.java
+++ b/rpki-rtr-server/src/test/java/net/ripe/rpki/rtr/RtrServerTest.java
@@ -72,7 +72,7 @@ public class RtrServerTest {
     private static final RtrPrefix AS_4444 = RtrDataUnit.prefix(Asn.parse("AS4444"), IpRange.parse("127.0.0.0/8"), 12);
 
     private final RtrCache rtrCache = new RtrCache(new SimpleMeterRegistry());
-    private final RtrClients clients = new RtrClients();
+    private final RtrClients clients = new RtrClients(new SimpleMeterRegistry());
     private final RtrClientHandler rtrClientHandler = new RtrClientHandler(rtrCache, clients);
     private final EmbeddedChannel channel = new EmbeddedChannel(
         new PduCodec(),

--- a/rpki-validator/Changelog.txt
+++ b/rpki-validator/Changelog.txt
@@ -1,4 +1,9 @@
-* Fri May 22 2020 Ties de Kock <tdekock@ripe.net> 3.1
+* Wed Jun 24 2020 Ties de Kock <tdekock@ripe.net> 3.1
+- Breaking: Rename prometheus metrics to follow naming standards. Validator
+metrics start with `rpkivalidator`, rtr server metrics start with `rtrserver`.
+- Add metric for active rtr connections.
+
+* Fri May 22 2020 Ties de Kock <tdekock@ripe.net> 3.1-2020.05.22.11.25
 Security update: Changed permissions for CentOS systemd service files
 
 After a change in our build infrastructure, the CentOS (rpm) artifact contained

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/TrustAnchorMetricsService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/metrics/TrustAnchorMetricsService.java
@@ -98,40 +98,40 @@ public class TrustAnchorMetricsService {
 
             this.rsyncPrefetchUri = trustAnchor.getLocations().get(0);
 
-            this.validationRunDuration = Timer.builder("validation.run.duration")
+            this.validationRunDuration = Timer.builder("rpkivalidator.validation.run.duration")
                     .description("Duration for the validation of the certificates descendant from this trust anchor.")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);
 
-            this.validationRunSuccessCount = Counter.builder("validation.run.count")
+            this.validationRunSuccessCount = Counter.builder("rpkivalidator.validation.run.total")
                     .description("Number of validation runs for the tree of certificates for this trust anchor.")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .tag("succeeded", "true")
                     .register(registry);
-            this.validationRunFailedCount = Counter.builder("validation.run.count")
+            this.validationRunFailedCount = Counter.builder("rpkivalidator.validation.run.total")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .tag("succeeded", "false")
                     .register(registry);
 
-            Gauge.builder("validation.results", objectCount::get)
+            Gauge.builder("rpkivalidator.validated.objects", objectCount::get)
                     .description("Status of the objects under this trust anchor (identical to numbers on front page of web interface)")
                     .tag("status", "total")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);
 
-            Gauge.builder("validation.results", errorCount::get)
+            Gauge.builder("rpkivalidator.validated.objects", errorCount::get)
                     .description("Status of the objects under this trust anchor (identical to numbers on front page of web interface)")
                     .tag("status", "error")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);
 
-            Gauge.builder("validation.results", warningCount::get)
+            Gauge.builder("rpkivalidator.validated.objects", warningCount::get)
                     .description("Status of the objects under this trust anchor (identical to numbers on front page of web interface)")
                     .tag("status", "warning")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);
 
-            Gauge.builder("last.validation.run", lastSuccessfulValidationRunTime::get)
+            Gauge.builder("rpkivalidator.last.validation.run", lastSuccessfulValidationRunTime::get)
                     .description("Timestamp (in seconds) of the last successful validation run.")
                     .tag("trust_anchor", rsyncPrefetchUri)
                     .register(registry);


### PR DESCRIPTION
  * Rename prometheus metrics to they follow the naming best
    practices [0].
  * Track the number of rtr server connections.

[0]: https://prometheus.io/docs/practices/naming/