### PR TITLE
Ignore RRDP delta withdrawal

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
@@ -311,7 +311,9 @@ public class RrdpServiceImpl implements RrdpService {
         final byte[] sha256 = deltaWithdraw.getHash();
         final Optional<RpkiObject> maybeObject = rpkiObjects.findBySha256(tx, sha256);
         if (maybeObject.isPresent()) {
-            rpkiObjects.deleteLocation(tx, maybeObject.get().key(), uri);
+            // The RpkiObjectCleanupJob will remove the object automatically. We cannot
+            // remove it here in case the object was also published by another repository
+            // (rsync or rrdp) or a malicious RRDP server fakes withdrawal.
             return true;
         } else {
             ValidationCheck validationCheck = new ValidationCheck(uri, ValidationCheck.Status.ERROR,


### PR DESCRIPTION
RPKI objects are automatically removed by the RpkiObjectCleanupJob, so there is no need to remove anything when a delta withdrawal is processed.

Removing the object on withdrawal (or update) should not be done since the object can also be published by another repository(rsync or rrdp) or a malicious RRDP server can fake a withdrawal.