### PR TITLE
Use Xodus logcache based on soft references

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/xodus/XodusImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/xodus/XodusImpl.java
@@ -64,12 +64,12 @@ public class XodusImpl extends Xodus {
             log.info("Creating Xodus environment at {}", dbPath);
 
             final EnvironmentConfig config = new EnvironmentConfig()
+                .setLogCacheUseSoftReferences(true)
                 .setLogDurableWrite(true)
                 .setEnvGatherStatistics(true)
                 .setGcEnabled(true)
                 .setLogCacheUseNio(true)
-                .setEnvCloseForcedly(true)
-                .setMemoryUsagePercentage(10);
+                .setEnvCloseForcedly(true);
 
             env = Environments.newInstance(dbPath, config);
 


### PR DESCRIPTION
Makes xodus use soft references for it's cache instead of a fixed
partition. This is documented in [0]. It is said to solve an issue [1]
where sequential writes fail due to out of memory.

[0]: https://youtrack.jetbrains.com/issue/XD-799
[1]: https://youtrack.jetbrains.com/issue/XD-768