### PR TITLE
Reduce BGP preview memory usage

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/SearchTerm.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/SearchTerm.java
@@ -32,17 +32,17 @@ package net.ripe.rpki.validator3.api;
 import net.ripe.ipresource.Asn;
 import net.ripe.ipresource.IpAddress;
 import net.ripe.ipresource.IpRange;
-import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
+import net.ripe.rpki.validator3.domain.ValidatedRoaPrefix;
 
 import java.util.function.Predicate;
 
 import static net.ripe.ipresource.IpResourceType.IPv4;
 
-public class SearchTerm implements Predicate<ValidatedRpkiObjects.RoaPrefix> {
+public class SearchTerm implements Predicate<ValidatedRoaPrefix> {
     private final String term;
     private final IpRange range;
     private final Long asn;
-    private final Predicate<ValidatedRpkiObjects.RoaPrefix> actualPredicate;
+    private final Predicate<ValidatedRoaPrefix> actualPredicate;
 
     private final static int IPv4_PREFIX_LENGTH = 32;
     private final static int IPv6_PREFIX_LENGTH = 128;
@@ -54,7 +54,7 @@ public class SearchTerm implements Predicate<ValidatedRpkiObjects.RoaPrefix> {
         actualPredicate = createPredicate();
     }
 
-    private Predicate<ValidatedRpkiObjects.RoaPrefix> createPredicate() {
+    private Predicate<ValidatedRoaPrefix> createPredicate() {
         if (asn != null) {
             return prefix -> asn == prefix.getAsn();
         }
@@ -80,7 +80,7 @@ public class SearchTerm implements Predicate<ValidatedRpkiObjects.RoaPrefix> {
         return term;
     }
 
-    public boolean test(ValidatedRpkiObjects.RoaPrefix prefix) {
+    public boolean test(ValidatedRoaPrefix prefix) {
         return actualPredicate.test(prefix);
     }
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/Sorting.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/Sorting.java
@@ -30,7 +30,7 @@
 package net.ripe.rpki.validator3.api;
 
 import lombok.Data;
-import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
+import net.ripe.rpki.validator3.domain.ValidatedRoaPrefix;
 
 import java.util.Comparator;
 import java.util.Locale;
@@ -50,29 +50,29 @@ public class Sorting {
         }
     }
 
-    public Comparator<? super ValidatedRpkiObjects.RoaPrefix> comparator() {
-        Comparator<ValidatedRpkiObjects.RoaPrefix> columns;
+    public Comparator<? super ValidatedRoaPrefix> comparator() {
+        Comparator<ValidatedRoaPrefix> columns;
         switch (by) {
             case PREFIX:
-                columns = Comparator.comparing(ValidatedRpkiObjects.RoaPrefix::getPrefix)
-                    .thenComparingInt(ValidatedRpkiObjects.RoaPrefix::getEffectiveLength)
-                    .thenComparing(ValidatedRpkiObjects.RoaPrefix::getAsn)
+                columns = Comparator.comparing(ValidatedRoaPrefix::getPrefix)
+                    .thenComparingInt(ValidatedRoaPrefix::getEffectiveLength)
+                    .thenComparing(ValidatedRoaPrefix::getAsn)
                     .thenComparing(p -> p.getTrustAnchor().getName());
                 break;
             case ASN:
-                columns = Comparator.comparing(ValidatedRpkiObjects.RoaPrefix::getAsn)
-                    .thenComparing(ValidatedRpkiObjects.RoaPrefix::getPrefix)
+                columns = Comparator.comparing(ValidatedRoaPrefix::getAsn)
+                    .thenComparing(ValidatedRoaPrefix::getPrefix)
                     .thenComparing(p -> p.getTrustAnchor().getName());
                 break;
             case LOCATION:
-                columns = Comparator.comparing((ValidatedRpkiObjects.RoaPrefix p) -> p.getLocations().first())
-                    .thenComparing((ValidatedRpkiObjects.RoaPrefix p) -> p.getTrustAnchor().getName());
+                columns = Comparator.comparing((ValidatedRoaPrefix p) -> p.getLocations().first())
+                    .thenComparing((ValidatedRoaPrefix p) -> p.getTrustAnchor().getName());
                 break;
             case TA:
             default:
-                columns = Comparator.comparing((ValidatedRpkiObjects.RoaPrefix p) -> p.getTrustAnchor().getName())
-                    .thenComparing(ValidatedRpkiObjects.RoaPrefix::getAsn)
-                    .thenComparing(ValidatedRpkiObjects.RoaPrefix::getPrefix);
+                columns = Comparator.comparing((ValidatedRoaPrefix p) -> p.getTrustAnchor().getName())
+                    .thenComparing(ValidatedRoaPrefix::getAsn)
+                    .thenComparing(ValidatedRoaPrefix::getPrefix);
                 break;
         }
         return direction == Direction.DESC ? columns.reversed() : columns;

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/bgp/BgpPreviewService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/bgp/BgpPreviewService.java
@@ -224,7 +224,7 @@ public class BgpPreviewService {
             }
             if (searchTerm.asAsn() != null) {
                 Long asn = searchTerm.asAsn();
-                return x -> asn == x.origin;
+                return x -> asn == Integer.toUnsignedLong(x.origin);
             }
             if (searchTerm.asIpRange() != null) {
                 IpRange range = searchTerm.asIpRange();
@@ -568,7 +568,7 @@ public class BgpPreviewService {
         final int bgpPrefixLength = bgpRisEntry.getPrefix().getPrefixLength();
         for (List<RoaPrefix> rs : roaPrefixes.findExactAndAllLessSpecific(bgpRisEntry.getPrefix())) {
             for (RoaPrefix r : rs) {
-                if (r.getAsn() == bgpRisEntry.origin) {
+                if (r.getAsn() == Integer.toUnsignedLong(bgpRisEntry.origin)) {
                     if (r.getEffectiveLength() < bgpPrefixLength) {
                         validity = Validity.INVALID_LENGTH;
                     } else {
@@ -583,7 +583,7 @@ public class BgpPreviewService {
     }
 
     private static Validity validateMatchingBgpRisEntry(RoaPrefix matchingRoaPrefix, BgpPreviewEntry bgpRisEntry) {
-        if (matchingRoaPrefix.getAsn() == bgpRisEntry.origin) {
+        if (matchingRoaPrefix.getAsn() == Integer.toUnsignedLong(bgpRisEntry.origin)) {
             if (matchingRoaPrefix.getEffectiveLength() < bgpRisEntry.getPrefix().getPrefixLength()) {
                 return Validity.INVALID_LENGTH;
             }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roaprefixassertions/RoaPrefixAssertionEntity.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roaprefixassertions/RoaPrefixAssertionEntity.java
@@ -1,0 +1,53 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.rpki.validator3.api.roaprefixassertions;
+
+import lombok.Getter;
+import net.ripe.ipresource.Asn;
+import net.ripe.ipresource.IpRange;
+import net.ripe.rpki.validator3.api.slurm.dtos.Slurm;
+import net.ripe.rpki.validator3.domain.RoaPrefixDefinition;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+
+public class RoaPrefixAssertionEntity extends Slurm.SlurmPrefixAssertion {
+
+    @Getter
+    private Long id;
+
+    public RoaPrefixAssertionEntity(Long id, Long asn, IpRange prefix,
+                                    @Min(0) @Max(128) Integer maxPrefixLength,
+                                    @Size(max = 2000) String comment) {
+        super(asn, prefix, maxPrefixLength, comment);
+        this.id = id;
+    }
+}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roaprefixassertions/RoaPrefixAssertionsController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roaprefixassertions/RoaPrefixAssertionsController.java
@@ -90,7 +90,7 @@ public class RoaPrefixAssertionsController {
         final Sorting sorting = Sorting.parse(sortBy, sortDirection);
         final Paging paging = Paging.of(startFrom, pageSize);
 
-        final List<RoaPrefixAssertion> matching = roaPrefixAssertionsService.find(searchTerm, sorting, paging).collect(Collectors.toList());
+        final List<RoaPrefixAssertionEntity> matching = roaPrefixAssertionsService.find(searchTerm, sorting, paging).collect(Collectors.toList());
 
         long totalSize = (int) roaPrefixAssertionsService.count(searchTerm);
 
@@ -123,7 +123,7 @@ public class RoaPrefixAssertionsController {
     @PostMapping(consumes = { ValidatorApi.API_MIME_TYPE, "application/json" })
     public ResponseEntity<ApiResponse<RoaPrefixAssertionResource>> add(@RequestBody @Valid ApiCommand<AddRoaPrefixAssertion> command) {
         final long id = roaPrefixAssertionsService.execute(command.getData());
-        final RoaPrefixAssertion ignoreFilter = roaPrefixAssertionsService.get(id);
+        final RoaPrefixAssertionEntity ignoreFilter = roaPrefixAssertionsService.get(id);
         final Link selfRel = linkTo(methodOn(RoaPrefixAssertionsController.class).get(id)).withSelfRel();
         return ResponseEntity.created(URI.create(selfRel.getHref())).body(ApiResponse.data(toResource(ignoreFilter)));
     }
@@ -134,7 +134,7 @@ public class RoaPrefixAssertionsController {
         return ResponseEntity.noContent().build();
     }
 
-    private RoaPrefixAssertionResource toResource(RoaPrefixAssertion assertion) {
+    private RoaPrefixAssertionResource toResource(RoaPrefixAssertionEntity assertion) {
         Long asn = assertion.getAsn();
         List<BgpPreviewService.BgpPreviewEntry> affected = bgpPreviewService.findAffected(
             assertion.getPrefix(),

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roaprefixassertions/RoaPrefixAssertionsService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roaprefixassertions/RoaPrefixAssertionsService.java
@@ -56,7 +56,7 @@ import java.util.stream.Stream;
 @Slf4j
 public class RoaPrefixAssertionsService {
     private final Object listenerLock = new Object();
-    private final List<Consumer<Collection<RoaPrefixAssertion>>> listeners = new ArrayList<>();
+    private final List<Consumer<Collection<RoaPrefixAssertionEntity>>> listeners = new ArrayList<>();
 
     private final SlurmStore slurmStore;
 
@@ -98,9 +98,9 @@ public class RoaPrefixAssertionsService {
         notifyListeners();
     }
 
-    public void addListener(Consumer<Collection<RoaPrefixAssertion>> listener) {
+    public void addListener(Consumer<Collection<RoaPrefixAssertionEntity>> listener) {
         synchronized (listenerLock) {
-            List<RoaPrefixAssertion> assertions = all().collect(Collectors.toList());
+            List<RoaPrefixAssertionEntity> assertions = all().collect(Collectors.toList());
             listener.accept(assertions);
             listeners.add(listener);
         }
@@ -108,18 +108,18 @@ public class RoaPrefixAssertionsService {
 
     private void notifyListeners() {
         synchronized (listenerLock) {
-            List<RoaPrefixAssertion> assertions = all().collect(Collectors.toList());
+            List<RoaPrefixAssertionEntity> assertions = all().collect(Collectors.toList());
             listeners.forEach(listener -> listener.accept(assertions));
         }
     }
 
 
-    public Stream<RoaPrefixAssertion> all() {
+    public Stream<RoaPrefixAssertionEntity> all() {
         return slurmStore.read().getPrefixAssertions().entrySet().stream()
                 .map(e -> makeIgnoreFilter(e.getKey(), e.getValue()));
     }
 
-    public Stream<RoaPrefixAssertion> find(SearchTerm searchTerm, Sorting sorting, Paging paging) {
+    public Stream<RoaPrefixAssertionEntity> find(SearchTerm searchTerm, Sorting sorting, Paging paging) {
         Stream<Map.Entry<Long, Slurm.SlurmPrefixAssertion>> all = slurmStore.read().getPrefixAssertions().entrySet().stream();
         all = applySearch(searchTerm, all).sorted(toOrderSpecifier(sorting));
         if (paging != null) {
@@ -128,8 +128,8 @@ public class RoaPrefixAssertionsService {
         return all.map(e -> makeIgnoreFilter(e.getKey(), e.getValue()));
     }
 
-    private RoaPrefixAssertion makeIgnoreFilter(Long id, Slurm.SlurmPrefixAssertion value) {
-        return new RoaPrefixAssertion(id, value.getAsn(), value.getPrefix(), value.getMaxPrefixLength(), value.getComment());
+    private RoaPrefixAssertionEntity makeIgnoreFilter(Long id, Slurm.SlurmPrefixAssertion value) {
+        return new RoaPrefixAssertionEntity(id, value.getAsn(), value.getPrefix(), value.getMaxPrefixLength(), value.getComment());
     }
 
     public Stream<Map.Entry<Long, Slurm.SlurmPrefixAssertion>> applySearch(SearchTerm searchTerm, Stream<Map.Entry<Long, Slurm.SlurmPrefixAssertion>> all) {
@@ -149,7 +149,7 @@ public class RoaPrefixAssertionsService {
         return applySearch(searchTerm, slurmStore.read().getPrefixAssertions().entrySet().stream()).count();
     }
 
-    public RoaPrefixAssertion get(long id) {
+    public RoaPrefixAssertionEntity get(long id) {
         final Slurm.SlurmPrefixAssertion prefixAssertion = slurmStore.read().getPrefixAssertions().get(id);
         if (prefixAssertion == null) {
             return null;

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ValidatedRoasController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/roas/ValidatedRoasController.java
@@ -39,6 +39,7 @@ import net.ripe.rpki.validator3.api.Metadata;
 import net.ripe.rpki.validator3.api.Paging;
 import net.ripe.rpki.validator3.api.SearchTerm;
 import net.ripe.rpki.validator3.api.Sorting;
+import net.ripe.rpki.validator3.domain.ValidatedRoaPrefix;
 import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,7 +76,7 @@ public class ValidatedRoasController {
         final Sorting sorting = Sorting.parse(sortBy, sortDirection);
         final Paging paging = Paging.of(startFrom, pageSize);
 
-        ValidatedRpkiObjects.ValidatedObjects<ValidatedRpkiObjects.RoaPrefix> currentlyValidatedRoaPrefixes = validatedRpkiObjects.findCurrentlyValidatedRoaPrefixes(searchTerm, sorting, paging);
+        ValidatedRpkiObjects.ValidatedObjects<ValidatedRoaPrefix> currentlyValidatedRoaPrefixes = validatedRpkiObjects.findCurrentlyValidatedRoaPrefixes(searchTerm, sorting, paging);
         final Stream<RoaPrefix> roas = currentlyValidatedRoaPrefixes.getObjects()
             .map(prefix -> new RoaPrefix(
                 String.valueOf(prefix.getAsn()),

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/RoaPrefixAssertion.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/RoaPrefixAssertion.java
@@ -27,26 +27,16 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-package net.ripe.rpki.validator3.api.roaprefixassertions;
+package net.ripe.rpki.validator3.domain;
 
-import lombok.Getter;
-import net.ripe.ipresource.Asn;
+import lombok.Value;
 import net.ripe.ipresource.IpRange;
-import net.ripe.rpki.validator3.api.slurm.dtos.Slurm;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Size;
-
-public class RoaPrefixAssertion extends Slurm.SlurmPrefixAssertion {
-
-    @Getter
-    private Long id;
-
-    public RoaPrefixAssertion(Long id, Long asn, IpRange prefix,
-                              @Min(0) @Max(128) Integer maxPrefixLength,
-                              @Size(max = 2000) String comment) {
-        super(asn, prefix, maxPrefixLength, comment);
-        this.id = id;
-    }
+@Value(staticConstructor = "of")
+public class RoaPrefixAssertion implements RoaPrefixDefinition {
+    long asn;
+    IpRange prefix;
+    Integer maximumLength;
+    Long roaPrefixAssertionId;
+    String comment;
 }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ValidatedRoaPrefix.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ValidatedRoaPrefix.java
@@ -1,0 +1,81 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.rpki.validator3.domain;
+
+import com.google.common.collect.ImmutableSortedSet;
+import lombok.Value;
+import net.ripe.ipresource.IpRange;
+import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
+
+import java.math.BigInteger;
+
+@Value
+public class ValidatedRoaPrefix implements RoaPrefixDefinition {
+    ValidatedRpkiObjects.TrustAnchorData trustAnchor;
+    int asn;
+    IpRange prefix;
+    short maximumLength;
+    long notBefore;
+    long notAfter;
+    BigInteger serialNumber;
+
+    // Most objects have only a single location, so in this case store a direct
+    // reference to the string, instead of a singleton set.
+    Object locations;
+
+    public static ValidatedRoaPrefix of(ValidatedRpkiObjects.TrustAnchorData trustAnchor, long asn, IpRange prefix, Integer maximumLength, long notBefore, long notAfter, BigInteger serialNumber, ImmutableSortedSet<String> locations) {
+        return new ValidatedRoaPrefix(
+                trustAnchor,
+                (int) asn,
+                prefix,
+                maximumLength == null ? -1 : maximumLength.shortValue(),
+                notBefore,
+                notAfter,
+                serialNumber,
+                locations == null ? ImmutableSortedSet.of() : locations.size() == 1 ? locations.first() : locations
+        );
+    }
+
+    public long getAsn() {
+        return Integer.toUnsignedLong(asn);
+    }
+
+    public Integer getMaximumLength() {
+        return maximumLength < 0 ? null : Integer.valueOf(maximumLength);
+    }
+
+    public ImmutableSortedSet<String> getLocations() {
+        if (locations instanceof String) {
+            return ImmutableSortedSet.of((String) locations);
+        } else {
+            return (ImmutableSortedSet<String>) locations;
+        }
+    }
+}

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/SearchTermTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/SearchTermTest.java
@@ -31,8 +31,8 @@ package net.ripe.rpki.validator3.api;
 
 import com.google.common.collect.ImmutableSortedSet;
 import net.ripe.ipresource.IpRange;
+import net.ripe.rpki.validator3.domain.ValidatedRoaPrefix;
 import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
-import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects.RoaPrefix;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -43,14 +43,14 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 public class SearchTermTest {
 
-    private final RoaPrefix prefixTest = RoaPrefix.of(null, 0, IpRange.parse("10.0.0.0/8"), 32, 32,
+    private final ValidatedRoaPrefix prefixTest = ValidatedRoaPrefix.of(null, 0, IpRange.parse("10.0.0.0/8"), 32,
             Instant.now().toEpochMilli(),Instant.now().plus(365, DAYS).toEpochMilli(), BigInteger.ONE,null);
-    private final RoaPrefix asnTest = RoaPrefix.of(null, 3642, null, 32, 32,
+    private final ValidatedRoaPrefix asnTest = ValidatedRoaPrefix.of(null, 3642, null, 32,
             Instant.now().toEpochMilli(),Instant.now().plus(365, DAYS).toEpochMilli(), BigInteger.ONE,null);
-    private final RoaPrefix genericTest = RoaPrefix.of(
+    private final ValidatedRoaPrefix genericTest = ValidatedRoaPrefix.of(
             ValidatedRpkiObjects.TrustAnchorData.of(1L, "Bla Anchor"),
             3642,
-            null, 32, 32,
+            null, 32,
             Instant.now().toEpochMilli(),Instant.now().plus(365, DAYS).toEpochMilli(), BigInteger.ONE,
             ImmutableSortedSet.of("Some location"));
 

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/bgp/BgpPreviewServiceTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/bgp/BgpPreviewServiceTest.java
@@ -35,9 +35,10 @@ import net.ripe.ipresource.Asn;
 import net.ripe.ipresource.IpRange;
 import net.ripe.rpki.validator3.api.ignorefilters.IgnoreFilter;
 import net.ripe.rpki.validator3.api.ignorefilters.IgnoreFilterService;
-import net.ripe.rpki.validator3.api.roaprefixassertions.RoaPrefixAssertion;
+import net.ripe.rpki.validator3.api.roaprefixassertions.RoaPrefixAssertionEntity;
 import net.ripe.rpki.validator3.api.roaprefixassertions.RoaPrefixAssertionsService;
 import net.ripe.rpki.validator3.api.slurm.SlurmStore;
+import net.ripe.rpki.validator3.domain.ValidatedRoaPrefix;
 import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
 import org.joda.time.DateTime;
 import org.junit.Before;
@@ -180,8 +181,8 @@ public class BgpPreviewServiceTest {
         );
     }
 
-    private ValidatedRpkiObjects.RoaPrefix roa(Asn asn, String prefix, Integer maximumLength) {
-        return ValidatedRpkiObjects.RoaPrefix.of(null, asn.longValue(), IpRange.parse(prefix), maximumLength, maximumLength != null ? maximumLength : IpRange.parse(prefix).getPrefixLength(),
+    private ValidatedRoaPrefix roa(Asn asn, String prefix, Integer maximumLength) {
+        return ValidatedRoaPrefix.of(null, asn.longValue(), IpRange.parse(prefix), maximumLength,
                 Instant.now().toEpochMilli(),Instant.now().plus(365, DAYS).toEpochMilli(), BigInteger.ONE,
                 ImmutableSortedSet.of());
     }
@@ -199,7 +200,7 @@ public class BgpPreviewServiceTest {
             }
         }, new RoaPrefixAssertionsService(slurmStore) {
             @Override
-            public Stream<RoaPrefixAssertion> all() {
+            public Stream<RoaPrefixAssertionEntity> all() {
                 return Stream.empty();
             }
         });

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/BgpPreviewEntryTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/BgpPreviewEntryTest.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.domain.validation;
 
 import com.pholser.junit.quickcheck.Property;

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/BgpPreviewEntryTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/BgpPreviewEntryTest.java
@@ -1,0 +1,48 @@
+package net.ripe.rpki.validator3.domain.validation;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import net.ripe.ipresource.Asn;
+import net.ripe.ipresource.IpRange;
+import net.ripe.ipresource.Ipv4Address;
+import net.ripe.ipresource.Ipv6Address;
+import net.ripe.rpki.validator3.api.bgp.BgpPreviewService;
+import org.junit.Assume;
+import org.junit.runner.RunWith;
+
+import java.math.BigInteger;
+
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(JUnitQuickcheck.class)
+public class BgpPreviewEntryTest {
+    @Property(trials = 1000)
+    public void should_store_ipv4_prefix_efficiently(int start) {
+        long value = Integer.toUnsignedLong(start);
+        int prefixLength = 32 - (Long.numberOfTrailingZeros((1L << 32) + value));
+        IpRange prefix = IpRange.prefix(new Ipv4Address(value), prefixLength);
+
+        BgpPreviewService.BgpPreviewEntry entry = BgpPreviewService.BgpPreviewEntry.of(Asn.parse("AS1"), prefix, BgpPreviewService.Validity.VALID);
+
+        assertEquals(prefix, entry.getPrefix());
+    }
+
+    private static BigInteger maxIpv6 = BigInteger.valueOf(2L).pow(128).subtract(BigInteger.ONE);
+
+    @Property(trials = 1000)
+    public void should_store_ipv6_prefix_efficiently(BigInteger value) {
+        assumeThat(value, greaterThanOrEqualTo(BigInteger.ZERO));
+        assumeThat(value, lessThan(maxIpv6));
+
+        int prefixLength = 128 - (value.getLowestSetBit() == -1 ? 0 : value.getLowestSetBit());
+        IpRange prefix = IpRange.prefix(new Ipv6Address(value), prefixLength);
+
+        BgpPreviewService.BgpPreviewEntry entry = BgpPreviewService.BgpPreviewEntry.of(Asn.parse("AS1"), prefix, BgpPreviewService.Validity.VALID);
+
+        assertEquals(prefix, entry.getPrefix());
+    }
+}


### PR DESCRIPTION
Shares ROA prefix instances between `BgpPreviewService` and `ValidatedRpkiObjects` and stores the `BgpPreviewEntry` data more efficiently. Together heap usage is reduced by about 75 MB.