### PR TITLE
Reduce Xodus memory usage by using a smaller log cache page size

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/xodus/XodusImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/xodus/XodusImpl.java
@@ -65,6 +65,10 @@ public class XodusImpl extends Xodus {
 
             final EnvironmentConfig config = new EnvironmentConfig()
                 .setLogCacheUseSoftReferences(true)
+                // Almost all RPKI objects are less than 2 KB so use that as the log cache page size.
+                // This avoids loading co-located objects that are unlikely to be needed, greatly
+                // reducing Xodus memory usage.
+                .setLogCachePageSize(2 * 1024)
                 .setLogDurableWrite(true)
                 .setEnvGatherStatistics(true)
                 .setGcEnabled(true)


### PR DESCRIPTION
The default log cache page size in Xodus is 64 KB. This is useful when
data that is used together is stored near eachother. However, in RPKI
most objects are addressed by the SHA-256 value of the object. This is
basically "random" so we do not get any advantage when loading objects
that are nearby to the object we're currently interested in.

Reducing this log page cache size to 2 KB ensures almost all RPKI
objects still fit and we do not waste CPU and memory loading
co-located objects that are very unlikely to be needed.

With this setting I've been able to run the RPKI validator with the
five RIR trust anchors for more than 13 hours using 512 MB maximum
heap size without issue. Much better than the current required 1536 MB
max heap size!

JVM options used: `-verbose:gc -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -Xms512M -Xmx512M`

CPU and heap usage:

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/159416/87776272-cb669980-c827-11ea-93d0-c39a7ef4b067.png">

Heap dump overview:

<img width="1399" alt="image" src="https://user-images.githubusercontent.com/159416/87776329-e3d6b400-c827-11ea-8ae9-269c28915049.png">

