### PR TITLE
BGP RIS download streaming parser

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/bgp/BgpRisDump.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/bgp/BgpRisDump.java
@@ -29,15 +29,15 @@
  */
 package net.ripe.rpki.validator3.api.bgp;
 
+import com.google.common.collect.ImmutableList;
 import lombok.Data;
 import org.joda.time.DateTime;
 
-import java.util.List;
 import java.util.Optional;
 
 @Data(staticConstructor = "of")
-public class BgpRisDump {
+public class BgpRisDump<T> {
     final String url;
     final DateTime lastModified;
-    final Optional<List<BgpRisEntry>> entries;
+    final Optional<ImmutableList<T>> entries;
 }

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/bgp/BgpRisDownloaderTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/bgp/BgpRisDownloaderTest.java
@@ -30,13 +30,13 @@
 package net.ripe.rpki.validator3.api.bgp;
 
 import net.ripe.rpki.validator3.IntegrationTest;
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -49,15 +49,19 @@ public class BgpRisDownloaderTest {
 
     @Test
     public void download_ipv4() {
-        BgpRisDump dump = bgpRisDownloader.fetch(
-            BgpRisDump.of("http://www.ris.ripe.net/dumps/riswhoisdump.IPv4.gz",null, Optional.empty()));
+        BgpRisDump<BgpRisEntry> dump = bgpRisDownloader.fetch(
+                BgpRisDump.of("http://www.ris.ripe.net/dumps/riswhoisdump.IPv4.gz", null, Optional.empty()),
+                Stream::of
+        );
         assertThat(dump.getEntries()).hasValueSatisfying(entries -> assertThat(entries.size()).isGreaterThan(800_000));
     }
 
     @Test
     public void download_ipv6() {
-        BgpRisDump dump = bgpRisDownloader.fetch(
-            BgpRisDump.of("http://www.ris.ripe.net/dumps/riswhoisdump.IPv6.gz",null, Optional.empty()));
+        BgpRisDump<BgpRisEntry> dump = bgpRisDownloader.fetch(
+                BgpRisDump.of("http://www.ris.ripe.net/dumps/riswhoisdump.IPv6.gz", null, Optional.empty()),
+                Stream::of
+        );
         assertThat(dump.getEntries()).hasValueSatisfying(entries -> assertThat(entries.size()).isGreaterThan(60_000));
     }
 }

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/bgp/BgpRisParsingTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/bgp/BgpRisParsingTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -63,6 +64,6 @@ public class BgpRisParsingTest {
     }
 
     private List<BgpRisEntry> parse(String content) throws UnsupportedEncodingException {
-        return BgpRisDownloader.parse(new ByteArrayInputStream(content.getBytes("UTF-8")));
+        return BgpRisDownloader.parse(new ByteArrayInputStream(content.getBytes("UTF-8"))).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Greatly reduced temporary memory usage during BGP RIS download. For example, the `IdentityMap` holding parsed prefixes was retaining around 150 MB of memory. Now we immediately transform the BGP RIS entries into memory optimized BgpRisPreviewEntry objects so we no longer need this.

With this change it is possible to start and run the validator with `-Xmx384m`, at least for a while with an initialized object cache.