### PR TITLE
Rrdp streaming parser

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ErrorCodes.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ErrorCodes.java
@@ -34,6 +34,7 @@ public class ErrorCodes {
     public static final String RRDP_FETCH_DELTAS = "rrdp.fetch.deltas";
     public static final String RRDP_PARSE_ERROR = "rrdp.parse.error";
     public static final String RRDP_WRONG_SNAPSHOT_HASH = "rrdp.wrong.snapshot.hash";
+    public static final String RRDP_WRONG_SNAPSHOT_SESSION = "rrdp.wrong.snapshot.session";
     public static final String RRDP_WRONG_DELTA_HASH = "rrdp.wrong.delta.hash";
     public static final String RRDP_WRONG_DELTA_SESSION = "rrdp.wrong.delta.session";
     public static final String RRDP_SERIAL_MISMATCH = "rrdp.serial.mismatch";

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpClient.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpClient.java
@@ -29,11 +29,18 @@
  */
 package net.ripe.rpki.validator3.rrdp;
 
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 public interface RrdpClient {
     <T> T readStream(String uri, Function<InputStream, T> reader);
 
     byte[] getBody(String uri);
+
+    <T> T processUsingTemporaryFile(String uri, HashFunction hashFunction, BiFunction<Path, HashCode, T> process);
 }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
@@ -124,7 +124,7 @@ public class RrdpServiceImpl implements RrdpService {
         if (notification.sessionId.equals(rpkiRepository.getRrdpSessionId())) {
             if (rpkiRepository.getRrdpSerial().compareTo(notification.serial) <= 0) {
                 try {
-                    List<DeltaInfo> orderedDeltas = verifyDeltaSerials(notification, rpkiRepository);
+                    List<DeltaInfo> orderedDeltas = verifyAndOrderDeltaSerials(notification, rpkiRepository);
                     rrdpProcessingPool.submit(() -> orderedDeltas
                             .parallelStream()
                             .map(di -> readDelta(notification, di))
@@ -208,7 +208,7 @@ public class RrdpServiceImpl implements RrdpService {
         return d;
     }
 
-    private List<DeltaInfo> verifyDeltaSerials(final Notification notification, RpkiRepository rpkiRepository) {
+    private List<DeltaInfo> verifyAndOrderDeltaSerials(final Notification notification, RpkiRepository rpkiRepository) {
         List<DeltaInfo> orderedDeltas = notification.getDeltas().stream()
                 .filter(d -> d.getSerial().compareTo(rpkiRepository.getRrdpSerial()) > 0)
                 .sorted(Comparator.comparing(DeltaInfo::getSerial))

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
@@ -49,6 +49,7 @@ import net.ripe.rpki.validator3.util.Sha256;
 import net.ripe.rpki.validator3.util.Time;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -60,6 +61,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -81,11 +83,17 @@ public class RrdpServiceImpl implements RrdpService {
 
     private final Storage storage;
 
+    private final ForkJoinPool rrdpProcessingPool;
+
     @Autowired
-    public RrdpServiceImpl(final RrdpClient rrdpClient,
-                           final RpkiObjects rpkiObjects,
-                           final RpkiRepositories rpkiRepositories,
-                           final Storage storage) {
+    public RrdpServiceImpl(
+            @Value("${rpki.validator.rrdp.repository.parallelism:4}") int rrdpProcessingParallelism,
+            final RrdpClient rrdpClient,
+            final RpkiObjects rpkiObjects,
+            final RpkiRepositories rpkiRepositories,
+            final Storage storage
+    ) {
+        this.rrdpProcessingPool = new ForkJoinPool(rrdpProcessingParallelism);
         this.rrdpClient = rrdpClient;
         this.rpkiObjects = rpkiObjects;
         this.rpkiRepositories = rpkiRepositories;
@@ -116,23 +124,16 @@ public class RrdpServiceImpl implements RrdpService {
         if (notification.sessionId.equals(rpkiRepository.getRrdpSessionId())) {
             if (rpkiRepository.getRrdpSerial().compareTo(notification.serial) <= 0) {
                 try {
-                    final List<Delta> deltas = notification.deltas.stream().
-                            filter(d -> d.getSerial().compareTo(rpkiRepository.getRrdpSerial()) > 0).
-                            sorted(Comparator.comparing(DeltaInfo::getSerial)).
-                            parallel().
-                            map(di -> readDelta(notification, di)).
-                            collect(Collectors.toList());
-
-                    verifyDeltaSerials(deltas, notification, rpkiRepository);
-
-                    deltas.forEach(d -> {
-                        storage.readTx0(tx -> verifyDeltaIsApplicable(tx, d));
-                        storage.writeTx0(tx -> {
-                            storeDelta(tx, d, validationRun, rpkiRepository, changedObjects);
-                            tx.afterCommit(() -> rpkiRepository.setRrdpSerial(rpkiRepository.getRrdpSerial().add(BigInteger.ONE)));
-                        });
-                    });
-
+                    List<DeltaInfo> orderedDeltas = verifyDeltaSerials(notification, rpkiRepository);
+                    rrdpProcessingPool.submit(() -> orderedDeltas
+                            .parallelStream()
+                            .map(di -> readDelta(notification, di))
+                            .forEachOrdered(d -> storage.writeTx0(tx -> {
+                                verifyDeltaIsApplicable(tx, d);
+                                storeDelta(tx, d, validationRun, rpkiRepository, changedObjects);
+                                tx.afterCommit(() -> rpkiRepository.setRrdpSerial(rpkiRepository.getRrdpSerial().add(BigInteger.ONE)));
+                            }))
+                    ).join();
                 } catch (RrdpException e) {
                     log.info("Processing deltas failed {}, falling back to snapshot processing.", e.getMessage());
                     final String errorCode = e.getErrorCode() != null ? e.getErrorCode() : ErrorCodes.RRDP_FETCH_DELTAS;
@@ -155,29 +156,31 @@ public class RrdpServiceImpl implements RrdpService {
     }
 
     private void readSnapshot(RpkiRepository rpkiRepository, RpkiRepositoryValidationRun validationRun, Notification notification, AtomicBoolean changedObjects) {
-        final AtomicReference<HashingInputStream> hashingStream = new AtomicReference<>();
-        final Pair<Snapshot, Long> timedSnapshot = Time.timed(() ->
-                rrdpClient.readStream(notification.snapshotUri, is -> {
-                    hashingStream.set(new HashingInputStream(Hashing.sha256(), is));
-                    return rrdpParser.snapshot(hashingStream.get());
-                }));
+        rrdpProcessingPool.submit(() -> {
+            final AtomicReference<HashingInputStream> hashingStream = new AtomicReference<>();
+            final Pair<Snapshot, Long> timedSnapshot = Time.timed(() ->
+                    rrdpClient.readStream(notification.snapshotUri, is -> {
+                        hashingStream.set(new HashingInputStream(Hashing.sha256(), is));
+                        return rrdpParser.snapshot(hashingStream.get());
+                    }));
 
-        final byte[] snapshotHash = hashingStream.get().hash().asBytes();
-        if (!Arrays.equals(Hex.parse(notification.snapshotHash), snapshotHash)) {
-            throw new RrdpException(ErrorCodes.RRDP_WRONG_SNAPSHOT_HASH, "Hash of the snapshot file " +
-                    notification.snapshotUri + " is " + Hex.format(snapshotHash) + ", but notification file says " + notification.snapshotHash);
-        }
+            final byte[] snapshotHash = hashingStream.get().hash().asBytes();
+            if (!Arrays.equals(Hex.parse(notification.snapshotHash), snapshotHash)) {
+                throw new RrdpException(ErrorCodes.RRDP_WRONG_SNAPSHOT_HASH, "Hash of the snapshot file " +
+                        notification.snapshotUri + " is " + Hex.format(snapshotHash) + ", but notification file says " + notification.snapshotHash);
+            }
 
-        log.info("Downloading/hashing/parsing snapshot time {}ms", timedSnapshot.getRight());
-        Long timedStoreSnapshot = Time.timed(() ->
-                storage.writeTx0(tx -> {
-                    storeSnapshot(tx, timedSnapshot.getLeft(), validationRun, changedObjects);
-                    rpkiRepository.setRrdpSessionId(notification.sessionId);
-                    rpkiRepository.setRrdpSerial(notification.serial);
-                    rpkiRepositories.update(tx, rpkiRepository);
-                }));
+            log.info("Downloading/hashing/parsing snapshot time {}ms", timedSnapshot.getRight());
+            Long timedStoreSnapshot = Time.timed(() ->
+                    storage.writeTx0(tx -> {
+                        storeSnapshot(tx, timedSnapshot.getLeft(), validationRun, changedObjects);
+                        rpkiRepository.setRrdpSessionId(notification.sessionId);
+                        rpkiRepository.setRrdpSerial(notification.serial);
+                        rpkiRepositories.update(tx, rpkiRepository);
+                    }));
 
-        log.info("Storing snapshot time {}ms", timedStoreSnapshot);
+            log.info("Storing snapshot time {}ms", timedStoreSnapshot);
+        }).join();
     }
 
     private Delta readDelta(Notification notification, DeltaInfo di) {
@@ -198,10 +201,18 @@ public class RrdpServiceImpl implements RrdpService {
             throw new RrdpException(ErrorCodes.RRDP_WRONG_DELTA_SESSION, "Session id of the delta (" + di +
                 ") is not the same as in the notification file: " + notification.sessionId);
         }
+        if (!d.getSerial().equals(di.getSerial())) {
+            throw new RrdpException(ErrorCodes.RRDP_SERIAL_MISMATCH, "Serial of the delta (" + d.getSerial() +
+                    ") is not the same as in the notification file: " + di);
+        }
         return d;
     }
 
-    private void verifyDeltaSerials(final List<Delta> orderedDeltas, final Notification notification, RpkiRepository rpkiRepository) {
+    private List<DeltaInfo> verifyDeltaSerials(final Notification notification, RpkiRepository rpkiRepository) {
+        List<DeltaInfo> orderedDeltas = notification.getDeltas().stream()
+                .filter(d -> d.getSerial().compareTo(rpkiRepository.getRrdpSerial()) > 0)
+                .sorted(Comparator.comparing(DeltaInfo::getSerial))
+                .collect(Collectors.toList());
         if (orderedDeltas.isEmpty()) {
             if (!rpkiRepository.getRrdpSerial().equals(notification.serial)) {
                 throw new RrdpException(ErrorCodes.RRDP_SERIAL_MISMATCH, "The current serial is " + rpkiRepository.getRrdpSerial() +
@@ -228,6 +239,7 @@ public class RrdpServiceImpl implements RrdpService {
                 }
             }
         }
+        return orderedDeltas;
     }
 
     /*

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/OnDeleteTrigger.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/OnDeleteTrigger.java
@@ -1,4 +1,0 @@
-package net.ripe.rpki.validator3.storage;
-
-public class OnDeleteTrigger {
-}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/OnDeleteTrigger.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/OnDeleteTrigger.java
@@ -1,0 +1,4 @@
+package net.ripe.rpki.validator3.storage;
+
+public class OnDeleteTrigger {
+}

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpClientStub.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpClientStub.java
@@ -29,15 +29,27 @@
  */
 package net.ripe.rpki.validator3.rrdp;
 
+import com.google.common.hash.HashCode;
+import com.google.common.hash.HashFunction;
+import net.ripe.rpki.validator3.api.util.BuildInformation;
+import net.ripe.rpki.validator3.domain.metrics.HttpClientMetricsService;
+import org.eclipse.jetty.client.HttpClient;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
-public class RrdpClientStub implements RrdpClient {
+public class RrdpClientStub extends HttpRrdpClient {
 
     private Map<String, byte[]> contents = new HashMap<>();
+
+    public RrdpClientStub() {
+        super(null, null, null);
+    }
 
     @Override
     public <T> T readStream(String uri, Function<InputStream, T> reader) {

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpParserTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpParserTest.java
@@ -43,8 +43,16 @@ public class RrdpParserTest {
 
     @Test
     public void should_parse_snapshot() throws Exception {
-        final Snapshot snapshot = new RrdpParser().snapshot(fileIS("rrdp/snapshot1.xml"));
-        assertNotNull(snapshot.asMap().get("rsync://bandito.ripe.net/repo/671570f06499fbd2d6ab76c4f22566fe49d5de60.cer"));
+        new RrdpParser().parseSnapshot(
+                fileIS("rrdp/snapshot1.xml"),
+                (snapshotInfo) -> {
+                    assertEquals("9df4b597-af9e-4dca-bdda-719cce2c4e28", snapshotInfo.getSessionId());
+                    assertEquals(BigInteger.ONE, snapshotInfo.getSerial());
+                },
+                (snapshotObject) -> {
+                    assertEquals("rsync://bandito.ripe.net/repo/671570f06499fbd2d6ab76c4f22566fe49d5de60.cer", snapshotObject.getUri());
+                }
+        );
     }
 
     @Test

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
@@ -71,7 +71,7 @@ public class RrdpServiceImplTest extends GenericStorageTest {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        subject = new RrdpServiceImpl(rrdpClient, this.getRpkiObjects(), this.getRpkiRepositories(), getStorage());
+        subject = new RrdpServiceImpl(1, rrdpClient, this.getRpkiObjects(), this.getRpkiRepositories(), getStorage());
     }
 
     @Test
@@ -135,6 +135,7 @@ public class RrdpServiceImplTest extends GenericStorageTest {
         final Ref<TrustAnchor> trustAnchorRef = rtx(tx -> this.getTrustAnchors().makeRef(tx, trustAnchor.key()));
         RpkiRepository rpkiRepository = wtx(tx -> this.getRpkiRepositories().register(tx,
                 trustAnchorRef, RRDP_RIPE_NET_NOTIFICATION_XML, RpkiRepository.Type.RRDP));
+        rpkiRepository.setRrdpSerial(BigInteger.valueOf(serial));
 
         final RrdpRepositoryValidationRun validationRun = wtx(tx -> {
             Ref<RpkiRepository> ref = this.getRpkiRepositories().makeRef(tx, rpkiRepository.key());
@@ -175,6 +176,7 @@ public class RrdpServiceImplTest extends GenericStorageTest {
         final Ref<TrustAnchor> trustAnchorRef = rtx(tx -> this.getTrustAnchors().makeRef(tx, trustAnchor.key()));
         RpkiRepository rpkiRepository = wtx(tx -> this.getRpkiRepositories().register(tx,
                 trustAnchorRef, RRDP_RIPE_NET_NOTIFICATION_XML, RpkiRepository.Type.RRDP));
+        rpkiRepository.setRrdpSerial(BigInteger.valueOf(serial));
 
         Ref<RpkiRepository> rpkiRepositoryRef = rtx(tx ->
                 this.getRpkiRepositories().makeRef(tx, rpkiRepository.key()));
@@ -421,6 +423,7 @@ public class RrdpServiceImplTest extends GenericStorageTest {
                 this.getValidationRuns().add(tx, new RrdpRepositoryValidationRun(rpkiRepositoryRef)));
         subject.storeRepository(rpkiRepository, validationRun);
         assertEquals(1, validationRun.getValidationChecks().size());
+        System.out.println(validationRun.getValidationChecks());
 
         final ValidationCheck validationCheck = validationRun.getValidationChecks().get(0);
         assertEquals(ErrorCodes.RRDP_SERIAL_MISMATCH, validationCheck.getKey());

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
@@ -53,7 +53,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -90,13 +89,12 @@ public class RrdpServiceImplTest extends GenericStorageTest {
         final RrdpRepositoryValidationRun validationRun = wtx(tx ->
                 this.getValidationRuns().add(tx, new RrdpRepositoryValidationRun(rpkiRepositoryRef)));
 
-        AtomicBoolean changedObjects = new AtomicBoolean();
         new RrdpParser().parseSnapshot(
                 Objects.fileIS("rrdp/snapshot2.xml"),
                 (snapshotInfo) -> {
                 },
                 (snapshotObject) -> {
-                    wtx0(tx -> subject.storeSnapshotObjects(tx, Collections.singleton(snapshotObject), validationRun, changedObjects));
+                    wtx0(tx -> subject.storeSnapshotObjects(tx, Collections.singleton(snapshotObject), validationRun));
                 }
         );
 

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
@@ -49,6 +49,7 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.UUID;
@@ -89,9 +90,15 @@ public class RrdpServiceImplTest extends GenericStorageTest {
         final RrdpRepositoryValidationRun validationRun = wtx(tx ->
                 this.getValidationRuns().add(tx, new RrdpRepositoryValidationRun(rpkiRepositoryRef)));
 
-        final Snapshot snapshot = new RrdpParser().snapshot(Objects.fileIS("rrdp/snapshot2.xml"));
         AtomicBoolean changedObjects = new AtomicBoolean();
-        wtx0(tx -> subject.storeSnapshot(tx, snapshot, validationRun, changedObjects));
+        new RrdpParser().parseSnapshot(
+                Objects.fileIS("rrdp/snapshot2.xml"),
+                (snapshotInfo) -> {
+                },
+                (snapshotObject) -> {
+                    wtx0(tx -> subject.storeSnapshotObjects(tx, Collections.singleton(snapshotObject), validationRun, changedObjects));
+                }
+        );
 
         final List<RpkiObject> objects = rtx(tx -> this.getRpkiObjects().values(tx));
         assertEquals(3, objects.size());
@@ -390,7 +397,7 @@ public class RrdpServiceImplTest extends GenericStorageTest {
         final Objects.Publish crl = new Objects.Publish("rsync://host/path/crl1.crl", Objects.aParseableCrl());
         rrdpClient.add(crl.uri, crl.content);
 
-        final byte[] snapshotXml = Objects.snapshotXml(3, sessionId, crl);
+        final byte[] snapshotXml = Objects.snapshotXml(4, sessionId, crl);
 
         final Objects.SnapshotInfo emptySnapshot = new Objects.SnapshotInfo(SNAPSHOT_URL, Sha256.hash(snapshotXml));
         rrdpClient.add(emptySnapshot.uri, snapshotXml);
@@ -422,8 +429,8 @@ public class RrdpServiceImplTest extends GenericStorageTest {
         final RrdpRepositoryValidationRun validationRun = wtx(tx ->
                 this.getValidationRuns().add(tx, new RrdpRepositoryValidationRun(rpkiRepositoryRef)));
         subject.storeRepository(rpkiRepository, validationRun);
-        assertEquals(1, validationRun.getValidationChecks().size());
         System.out.println(validationRun.getValidationChecks());
+        assertEquals(1, validationRun.getValidationChecks().size());
 
         final ValidationCheck validationCheck = validationRun.getValidationChecks().get(0);
         assertEquals(ErrorCodes.RRDP_SERIAL_MISMATCH, validationCheck.getKey());

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/IxMapTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/IxMapTest.java
@@ -299,12 +299,10 @@ public abstract class IxMapTest {
     public void testOnDeleteCascade() {
         final Set<Key> deleteKeys = new HashSet<>();
         ixMap.onDelete((tx, k) -> deleteKeys.add(k));
-        putAndGet("a");
-        putAndGet("bbb");
+        Key ka = putAndGet("a");
+        Key kb = putAndGet("bbb");
         putAndGet("ttt");
 
-        Key ka = Key.of("a");
-        Key kb = Key.of("bbb");
         wtx0(tx -> {
                     ixMap.delete(tx, ka);
                     ixMap.delete(tx, kb);


### PR DESCRIPTION
Streaming parsing of RRDP snapshots. Objects are committed to the database in batches (1 MB in size) to avoid using too much memory. To avoid referring to objects that are not yet committed manifests are stored last. This is implemented by parsing the snapshot twice. Other approaches added quite a lot of complication (updating the AKI MFT index only at the end) or used too much memory (keeping all manifests in memory until the end).