### PR TITLE
Limit total Xodus cache size to avoid high GC load

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/xodus/XodusImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/xodus/XodusImpl.java
@@ -65,6 +65,11 @@ public class XodusImpl extends Xodus {
 
             final EnvironmentConfig config = new EnvironmentConfig()
                 .setLogCacheUseSoftReferences(true)
+                // Limit total memory usage of Xodus to avoid heavy garbage collector load.
+                // Soft-references ensure that the JVM will not run out of memory because of
+                // the Xodus cache, but can still cause a lot of GC work before the soft
+                // references are released.
+                .setMemoryUsagePercentage(10)
                 // Almost all RPKI objects are less than 2 KB so use that as the log cache page size.
                 // This avoids loading co-located objects that are unlikely to be needed, greatly
                 // reducing Xodus memory usage.


### PR DESCRIPTION
Soft-references ensure that the JVM will not run out of memory because of the Xodus cache, but can still cause a lot of GC work before the soft references are released.

Before the maximum JVM monitoring shows

<img width="1766" alt="image" src="https://user-images.githubusercontent.com/159416/88627916-632c7900-d0ad-11ea-97d7-c83df22b22f2.png">

Notice the GC activity line, which sometimes goes up to 5% and stays there for a few minutes. CPU usage is also very high during this time. According to the time command the process monitored here was using about 150% CPU on average:

```
real	3758m16.149s
user	5423m59.238s
sys	131m41.200s
```

With the maximum set to 10% (of 384 MB heap) the graph changes:

<img width="1759" alt="image" src="https://user-images.githubusercontent.com/159416/88628108-b30b4000-d0ad-11ea-8fce-28813d46eb46.png">

High CPU usage spikes are much lower and probably correspond to certificate tree validation runs. Heap space usage is also more steady. GC activity is always low. CPU usage now averages about 50%:

```
real	1341m32.170s
user	674m34.702s
sys	25m58.822s
```

Note that disk IO should still be limited, since the OS page cache should do most of this work. With a smaller heap for the JVM there is also more OS page cache available.


