### PR TITLE
Do not store passing checks

### DIFF
--- a/rpki-parent/pom.xml
+++ b/rpki-parent/pom.xml
@@ -18,7 +18,7 @@
 
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
-        <rpki-commons.version>1.11.1-SNAPSHOT</rpki-commons.version>
+        <rpki-commons.version>1.12.0</rpki-commons.version>
 
         <!-- Micrometer.version from spring boot -->
 

--- a/rpki-parent/pom.xml
+++ b/rpki-parent/pom.xml
@@ -18,7 +18,7 @@
 
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
-        <rpki-commons.version>1.11.0</rpki-commons.version>
+        <rpki-commons.version>1.11.1-SNAPSHOT</rpki-commons.version>
 
         <!-- Micrometer.version from spring boot -->
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/rpkiobjects/RpkiObjectController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/rpkiobjects/RpkiObjectController.java
@@ -97,6 +97,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static net.ripe.rpki.validator3.domain.RpkiObjectUtils.newValidationResult;
+
 @Api(tags = "RPKI objects")
 @PublicApiCall
 @RestController
@@ -139,8 +141,8 @@ public class RpkiObjectController {
                     final SortedSet<String> locations = triple.getMiddle();
                     Optional<ValidationCheck> vc = triple.getRight();
                     return mapRpkiObject(rpkiObject, vc
-                            .map(c -> ValidationResult.withLocation(c.getLocation()).withoutStoringPassingChecks())
-                            .orElse(ValidationResult.withLocation(location(rpkiObject.getType(), locations))).withoutStoringPassingChecks());
+                            .map(c -> newValidationResult(c.getLocation()))
+                            .orElse(newValidationResult(location(rpkiObject.getType(), locations))));
                 })
                 .filter(Objects::nonNull);
     }
@@ -184,7 +186,7 @@ public class RpkiObjectController {
                 collect(Collectors.toList()).
                 parallelStream().
                 map(bytes -> {
-                    ValidationResult vr = ValidationResult.withLocation("whatever." + fileExtension).withoutStoringPassingChecks();
+                    ValidationResult vr = newValidationResult("whatever." + fileExtension);
                     return CertificateRepositoryObjectFactory.createCertificateRepositoryObject(bytes, vr);
                 });
     }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/rpkiobjects/RpkiObjectController.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/rpkiobjects/RpkiObjectController.java
@@ -139,8 +139,8 @@ public class RpkiObjectController {
                     final SortedSet<String> locations = triple.getMiddle();
                     Optional<ValidationCheck> vc = triple.getRight();
                     return mapRpkiObject(rpkiObject, vc
-                            .map(c -> ValidationResult.withLocation(c.getLocation()))
-                            .orElse(ValidationResult.withLocation(location(rpkiObject.getType(), locations))));
+                            .map(c -> ValidationResult.withLocation(c.getLocation()).withoutStoringPassingChecks())
+                            .orElse(ValidationResult.withLocation(location(rpkiObject.getType(), locations))).withoutStoringPassingChecks());
                 })
                 .filter(Objects::nonNull);
     }
@@ -184,7 +184,7 @@ public class RpkiObjectController {
                 collect(Collectors.toList()).
                 parallelStream().
                 map(bytes -> {
-                    final ValidationResult vr = ValidationResult.withLocation("whatever." + fileExtension);
+                    ValidationResult vr = ValidationResult.withLocation("whatever." + fileExtension).withoutStoringPassingChecks();
                     return CertificateRepositoryObjectFactory.createCertificateRepositoryObject(bytes, vr);
                 });
     }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectUtils.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectUtils.java
@@ -41,7 +41,7 @@ import static net.ripe.rpki.commons.validation.ValidationString.OBJECTS_GENERAL_
 public class RpkiObjectUtils {
 
     public static Either<ValidationResult, Pair<String, RpkiObject>> createRpkiObject(final String uri, final byte[] content) {
-        ValidationResult validationResult = ValidationResult.withLocation(uri);
+        ValidationResult validationResult = ValidationResult.withLocation(uri).withoutStoringPassingChecks();
         CertificateRepositoryObject repositoryObject = CertificateRepositoryObjectFactory.createCertificateRepositoryObject(content, validationResult);
         if (validationResult.hasFailures()) {
             return Either.left(validationResult);

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectUtils.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/RpkiObjectUtils.java
@@ -32,16 +32,40 @@ package net.ripe.rpki.validator3.domain;
 import fj.data.Either;
 import net.ripe.rpki.commons.crypto.CertificateRepositoryObject;
 import net.ripe.rpki.commons.crypto.util.CertificateRepositoryObjectFactory;
+import net.ripe.rpki.commons.validation.ValidationLocation;
 import net.ripe.rpki.commons.validation.ValidationResult;
 import net.ripe.rpki.validator3.storage.data.RpkiObject;
 import org.apache.commons.lang3.tuple.Pair;
+
+import java.net.URI;
 
 import static net.ripe.rpki.commons.validation.ValidationString.OBJECTS_GENERAL_PARSING;
 
 public class RpkiObjectUtils {
 
+    /**
+     * @return ValidationResult that will not store passing checks.
+     */
+    public static ValidationResult newValidationResult(String location) {
+        return ValidationResult.withLocation(location).withoutStoringPassingChecks();
+    }
+
+    /**
+     * @return ValidationResult that will not store passing checks.
+     */
+    public static ValidationResult newValidationResult(URI location) {
+        return ValidationResult.withLocation(location).withoutStoringPassingChecks();
+    }
+
+    /**
+     * @return ValidationResult that will not store passing checks.
+     */
+    public static ValidationResult newValidationResult(ValidationLocation location) {
+        return ValidationResult.withLocation(location).withoutStoringPassingChecks();
+    }
+
     public static Either<ValidationResult, Pair<String, RpkiObject>> createRpkiObject(final String uri, final byte[] content) {
-        ValidationResult validationResult = ValidationResult.withLocation(uri).withoutStoringPassingChecks();
+        ValidationResult validationResult = newValidationResult(uri);
         CertificateRepositoryObject repositoryObject = CertificateRepositoryObjectFactory.createCertificateRepositoryObject(content, validationResult);
         if (validationResult.hasFailures()) {
             return Either.left(validationResult);

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationService.java
@@ -171,7 +171,7 @@ public class CertificateTreeValidationService {
         final CertificateTreeValidationRun validationRun = new CertificateTreeValidationRun(trustAnchorRef);
 
         String trustAnchorLocation = trustAnchor.getLocations().get(0);
-        ValidationResult validationResult = ValidationResult.withLocation(trustAnchorLocation);
+        ValidationResult validationResult = ValidationResult.withLocation(trustAnchorLocation).withoutStoringPassingChecks();
 
         try {
             X509ResourceCertificate trustAnchorCertificate = trustAnchor.getCertificate();
@@ -240,7 +240,7 @@ public class CertificateTreeValidationService {
         rpkiObjects.findLatestMftByAKI(tx, taCertificate.getSubjectKeyIdentifier())
             .ifPresent(manifest -> {
                 rpkiObjects.markReachable(tx, manifest.key(), now);
-                manifest.get(ManifestCms.class, ValidationResult.withLocation("ta-manifest.mft"))
+                manifest.get(ManifestCms.class, ValidationResult.withLocation("ta-manifest.mft").withoutStoringPassingChecks())
                     .ifPresent(manifestCms ->
                         rpkiObjects.findObjectsInManifest(tx, manifestCms)
                             .forEach((entry, rpkiObject) ->
@@ -261,7 +261,7 @@ public class CertificateTreeValidationService {
                                               final Accumulator accumulator) {
 
         ValidationLocation certificateLocation = validationResult.getCurrentLocation();
-        ValidationResult temporary = ValidationResult.withLocation(certificateLocation);
+        ValidationResult temporary = ValidationResult.withLocation(certificateLocation).withoutStoringPassingChecks();
         try {
             RpkiRepository rpkiRepository = Bench.mark(trustAnchor.getName(),"registerRepository", () ->
                 storage.writeTx(tx -> registerRepository(tx, trustAnchor, registeredRepositories, context)));
@@ -361,7 +361,7 @@ public class CertificateTreeValidationService {
     private Stream<Tuple3<URI, RpkiObject, ValidationResult>> getManifestEntry(URI manifestUri,
                                                                                Map.Entry<String, byte[]> entry) {
         URI location = manifestUri.resolve(entry.getKey());
-        ValidationResult temporary = ValidationResult.withLocation(new ValidationLocation(location));
+        ValidationResult temporary = ValidationResult.withLocation(new ValidationLocation(location)).withoutStoringPassingChecks();
 
         Optional<RpkiObject> object = storage.readTx(tx -> rpkiObjects.findBySha256(tx, entry.getValue()));
         temporary.rejectIfFalse(object.isPresent(), VALIDATOR_MANIFEST_ENTRY_FOUND, manifestUri.toASCIIString());

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
@@ -132,7 +132,7 @@ public class RpkiRepositoryValidationService {
             return;
         }
         log.info("Starting RPKI repository validation for " + rpkiRepository);
-        final ValidationResult validationResult = ValidationResult.withLocation(rpkiRepository.getRrdpNotifyUri());
+        final ValidationResult validationResult = ValidationResult.withLocation(rpkiRepository.getRrdpNotifyUri()).withoutStoringPassingChecks();
 
         final RpkiRepositoryValidationRun validationRun = storage.writeTx(tx -> {
             Ref<RpkiRepository> rpkiRepositoryRef = rpkiRepositories.makeRef(tx, rpkiRepository.key());
@@ -212,7 +212,7 @@ public class RpkiRepositoryValidationService {
                     return processRsyncRepository(affectedTrustAnchors, validationRun, fetchedLocations, existingObjectKeys, repository);
                 }
             ).collect(
-                () -> ValidationResult.withLocation("placeholder"),
+                () -> ValidationResult.withLocation("placeholder").withoutStoringPassingChecks(),
                 ValidationResult::addAll,
                 ValidationResult::addAll
             );
@@ -236,7 +236,7 @@ public class RpkiRepositoryValidationService {
 
             final RsyncRepositoryValidationRun validationRun = makeAndStoreRsyncValidationRun();
 
-            final ValidationResult validationResult = ValidationResult.withLocation(URI.create(repository.getRsyncRepositoryUri()));
+            final ValidationResult validationResult = ValidationResult.withLocation(URI.create(repository.getRsyncRepositoryUri())).withoutStoringPassingChecks();
             storage.writeTx0(tx -> validationRuns.associate(tx, validationRun, repository));
 
             final Set<String> existingObjectsBySha256 = new HashSet<>();
@@ -270,7 +270,7 @@ public class RpkiRepositoryValidationService {
                                                     Set<String> existingObjectsSha256,
                                                     RpkiRepository repository) {
 
-        final ValidationResult validationResult = ValidationResult.withLocation(URI.create(repository.getRsyncRepositoryUri()));
+        final ValidationResult validationResult = ValidationResult.withLocation(URI.create(repository.getRsyncRepositoryUri())).withoutStoringPassingChecks();
 
         try {
             File targetDirectory = Rsync.localFileFromRsyncUri(

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
@@ -83,6 +83,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+import static net.ripe.rpki.validator3.domain.RpkiObjectUtils.newValidationResult;
+
 @Service
 @Slf4j
 public class RpkiRepositoryValidationService {
@@ -132,7 +134,7 @@ public class RpkiRepositoryValidationService {
             return;
         }
         log.info("Starting RPKI repository validation for " + rpkiRepository);
-        final ValidationResult validationResult = ValidationResult.withLocation(rpkiRepository.getRrdpNotifyUri()).withoutStoringPassingChecks();
+        final ValidationResult validationResult = newValidationResult(rpkiRepository.getRrdpNotifyUri());
 
         final RpkiRepositoryValidationRun validationRun = storage.writeTx(tx -> {
             Ref<RpkiRepository> rpkiRepositoryRef = rpkiRepositories.makeRef(tx, rpkiRepository.key());
@@ -212,7 +214,7 @@ public class RpkiRepositoryValidationService {
                     return processRsyncRepository(affectedTrustAnchors, validationRun, fetchedLocations, existingObjectKeys, repository);
                 }
             ).collect(
-                () -> ValidationResult.withLocation("placeholder").withoutStoringPassingChecks(),
+                () -> newValidationResult("placeholder"),
                 ValidationResult::addAll,
                 ValidationResult::addAll
             );
@@ -236,7 +238,7 @@ public class RpkiRepositoryValidationService {
 
             final RsyncRepositoryValidationRun validationRun = makeAndStoreRsyncValidationRun();
 
-            final ValidationResult validationResult = ValidationResult.withLocation(URI.create(repository.getRsyncRepositoryUri())).withoutStoringPassingChecks();
+            final ValidationResult validationResult = newValidationResult(repository.getRsyncRepositoryUri());
             storage.writeTx0(tx -> validationRuns.associate(tx, validationRun, repository));
 
             final Set<String> existingObjectsBySha256 = new HashSet<>();
@@ -270,7 +272,7 @@ public class RpkiRepositoryValidationService {
                                                     Set<String> existingObjectsSha256,
                                                     RpkiRepository repository) {
 
-        final ValidationResult validationResult = ValidationResult.withLocation(URI.create(repository.getRsyncRepositoryUri())).withoutStoringPassingChecks();
+        final ValidationResult validationResult = newValidationResult(repository.getRsyncRepositoryUri());
 
         try {
             File targetDirectory = Rsync.localFileFromRsyncUri(

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationService.java
@@ -119,7 +119,7 @@ public class TrustAnchorValidationService {
         });
 
         final ValidationLocation trustAnchorValidationLocation = new ValidationLocation(validationRun.getTrustAnchorCertificateURI());
-        ValidationResult validationResult = ValidationResult.withLocation(trustAnchorValidationLocation);
+        ValidationResult validationResult = ValidationResult.withLocation(trustAnchorValidationLocation).withoutStoringPassingChecks();
 
         boolean updatedTrustAnchor = false;
         try {

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationService.java
@@ -67,6 +67,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static net.ripe.rpki.validator3.domain.RpkiObjectUtils.newValidationResult;
+
 @Service
 @Slf4j
 public class TrustAnchorValidationService {
@@ -119,7 +121,7 @@ public class TrustAnchorValidationService {
         });
 
         final ValidationLocation trustAnchorValidationLocation = new ValidationLocation(validationRun.getTrustAnchorCertificateURI());
-        ValidationResult validationResult = ValidationResult.withLocation(trustAnchorValidationLocation).withoutStoringPassingChecks();
+        ValidationResult validationResult = newValidationResult(trustAnchorValidationLocation);
 
         boolean updatedTrustAnchor = false;
         try {

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiObject.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiObject.java
@@ -58,6 +58,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static net.ripe.rpki.validator3.domain.RpkiObjectUtils.newValidationResult;
+
 @EqualsAndHashCode(callSuper = true)
 @Data
 @Binary
@@ -149,7 +151,7 @@ public class RpkiObject extends Base<RpkiObject> {
     }
 
     public <T extends CertificateRepositoryObject> Optional<T> get(Class<T> clazz, ValidationResult validationResult) {
-        ValidationResult temporary = ValidationResult.withLocation(validationResult.getCurrentLocation()).withoutStoringPassingChecks();
+        ValidationResult temporary = newValidationResult(validationResult.getCurrentLocation());
         try {
             return get(clazz, validationResult.getCurrentLocation().getName());
         } finally {

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiObject.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiObject.java
@@ -149,7 +149,7 @@ public class RpkiObject extends Base<RpkiObject> {
     }
 
     public <T extends CertificateRepositoryObject> Optional<T> get(Class<T> clazz, ValidationResult validationResult) {
-        ValidationResult temporary = ValidationResult.withLocation(validationResult.getCurrentLocation());
+        ValidationResult temporary = ValidationResult.withLocation(validationResult.getCurrentLocation()).withoutStoringPassingChecks();
         try {
             return get(clazz, validationResult.getCurrentLocation().getName());
         } finally {
@@ -158,9 +158,9 @@ public class RpkiObject extends Base<RpkiObject> {
     }
 
     public <T extends CertificateRepositoryObject> Optional<T> get(final Class<T> clazz, final String location) {
-        ValidationResult temporary = ValidationResult.withLocation(location);
+        ValidationResult temporary = ValidationResult.withLocation(location).withoutStoringPassingChecks();
 
-        ValidationResult ignored = ValidationResult.withLocation(location);
+        ValidationResult ignored = ValidationResult.withLocation(location).withoutStoringPassingChecks();
         CertificateRepositoryObject candidate = Bench.mark("createCertificateRepositoryObject", () ->
             CertificateRepositoryObjectFactory.createCertificateRepositoryObject(
                 encoded,

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/TrustAnchor.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/TrustAnchor.java
@@ -47,6 +47,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static net.ripe.rpki.validator3.domain.RpkiObjectUtils.newValidationResult;
+
 @EqualsAndHashCode(callSuper = true)
 @Binary
 @ToString(exclude = {"encodedCertificate", "subjectPublicKeyInfo"})
@@ -94,7 +96,7 @@ public class TrustAnchor extends Base<TrustAnchor> {
 
         return (X509ResourceCertificate) CertificateRepositoryObjectFactory.createCertificateRepositoryObject(
                 encodedCertificate,
-                ValidationResult.withLocation(locations.get(0)).withoutStoringPassingChecks()
+                newValidationResult(locations.get(0))
         );
     }
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/TrustAnchor.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/TrustAnchor.java
@@ -94,7 +94,7 @@ public class TrustAnchor extends Base<TrustAnchor> {
 
         return (X509ResourceCertificate) CertificateRepositoryObjectFactory.createCertificateRepositoryObject(
                 encodedCertificate,
-                ValidationResult.withLocation(locations.get(0))
+                ValidationResult.withLocation(locations.get(0)).withoutStoringPassingChecks()
         );
     }
 


### PR DESCRIPTION
The validator does not use or store passing checks but they take up a
lot of memory during validation. Without storing these checks the peak
memory usage of the validator is reduced.

With all the other fixes (streaming RRDP, incremental rsync import)
the validator can now run with maximum heap size of 256 MB with
the five RIR trust anchors.
