### PR TITLE
Parse RRDP snapshot RPKI objects in parallel for improved performance

### DIFF
--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
@@ -94,7 +94,7 @@ public class RrdpServiceImplTest extends GenericStorageTest {
                 (snapshotInfo) -> {
                 },
                 (snapshotObject) -> {
-                    wtx0(tx -> subject.storeSnapshotObjects(tx, Collections.singleton(snapshotObject), validationRun));
+                    wtx0(tx -> subject.storeSnapshotObjects(tx, Collections.singletonList(snapshotObject), validationRun));
                 }
         );
 


### PR DESCRIPTION
Similar to parallel parsing in the rsync implementation of https://github.com/RIPE-NCC/rpki-validator-3/pull/246