### PR TITLE
Corrupted snapshot must be monitored and used to trigger alert

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ErrorCodes.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ErrorCodes.java
@@ -42,6 +42,7 @@ public class ErrorCodes {
     public static final String RRDP_WITHDRAW_NONEXISTENT_OBJECT = "rrdp.withdraw.nonexistent.object";
     public static final String RRDP_SNAPSHOT_FETCH_LOCAL_AHEAD = "rrdp.fetch.snapshot.local.ahead";
     public static final String RRDP_SNAPSHOT_FETCH_NEW_SESSION = "rrdp.fetch.snapshot.new.session";
+    public static final String RRDP_CORRUPTED_SNAPSHOT = "rrdp.corrupted.snapshot";
 
 
     public static final String RSYNC_FETCH = "rsync.fetch";

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
@@ -225,7 +225,7 @@ public class RrdpServiceImpl implements RrdpService {
                     in,
                     (snapshotInfo) -> {
                         if (!notification.sessionId.equals(snapshotInfo.getSessionId())) {
-                            rrdpMetrics.update(notification.snapshotUri, ErrorCodes.RRDP_WRONG_SNAPSHOT_HASH);
+                            rrdpMetrics.update(notification.snapshotUri, ErrorCodes.RRDP_WRONG_SNAPSHOT_SESSION);
                             throw new RrdpException(ErrorCodes.RRDP_WRONG_SNAPSHOT_SESSION, "Session id of the snapshot (" + snapshotInfo.getSessionId() +
                                     ") is not the same as in the notification file: " + notification.sessionId);
                         }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
@@ -225,6 +225,7 @@ public class RrdpServiceImpl implements RrdpService {
                     in,
                     (snapshotInfo) -> {
                         if (!notification.sessionId.equals(snapshotInfo.getSessionId())) {
+                            rrdpMetrics.update(notification.snapshotUri, ErrorCodes.RRDP_WRONG_SNAPSHOT_HASH);
                             throw new RrdpException(ErrorCodes.RRDP_WRONG_SNAPSHOT_SESSION, "Session id of the snapshot (" + snapshotInfo.getSessionId() +
                                     ") is not the same as in the notification file: " + notification.sessionId);
                         }
@@ -253,6 +254,7 @@ public class RrdpServiceImpl implements RrdpService {
 
             return counter.get();
         } catch (IOException e) {
+            rrdpMetrics.update(notification.snapshotUri, ErrorCodes.RRDP_CORRUPTED_SNAPSHOT);
             throw new RrdpException("Couldn't read snapshot: ", e);
         }
     }
@@ -261,6 +263,7 @@ public class RrdpServiceImpl implements RrdpService {
         final byte[] deltaBody = rrdpClient.getBody(di.getUri());
         final byte[] deltaHash = Sha256.hash(deltaBody);
         if (!Arrays.equals(Hex.parse(di.getHash()), deltaHash)) {
+            rrdpMetrics.update(notification.snapshotUri, ErrorCodes.RRDP_WRONG_DELTA_HASH);
             throw new RrdpException(ErrorCodes.RRDP_WRONG_DELTA_HASH, "Hash of the delta file " + di + " is " + Hex.format(deltaHash) +
                     ", but notification file says " + di.getHash());
         }


### PR DESCRIPTION
Some of these thrown RrdpException needs to be monitored. Especially corrupt rrdp snapshot. 
