### PR TITLE
Http streaming timeouts and sequental RRDP downloading

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImpl.java
@@ -144,7 +144,7 @@ public class RrdpServiceImpl implements RrdpService {
                 try {
                     List<DeltaInfo> orderedDeltas = verifyAndOrderDeltaSerials(notification, rpkiRepository);
                     rrdpProcessingPool.submit(() -> orderedDeltas
-                            .parallelStream()
+                            .stream()
                             .map(di -> readDelta(notification, di))
                             .forEachOrdered(d -> storage.writeTx0(tx -> {
                                 verifyDeltaIsApplicable(tx, d);

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/HttpStreaming.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/HttpStreaming.java
@@ -55,11 +55,13 @@ public class HttpStreaming {
         InputStreamResponseListener listener = new InputStreamResponseListener();
 
         Request request = requestF.get();
+        request.timeout(1, TimeUnit.HOURS);
+        request.idleTimeout(1, TimeUnit.MINUTES);
         request.send(listener);
 
         Response response = null;
         try {
-            response = listener.get(30, TimeUnit.SECONDS);
+            response = listener.get(2, TimeUnit.MINUTES);
 
             if (response.getStatus() != 200) {
                 if (response.getStatus() == 304) {


### PR DESCRIPTION
See if this fixes a problem with "hanging" RPKI validators.

Normal case there will be very few deltas for a single RRDP
repository. When there are many it is useful to ensure that the first
delta is downloaded and processed first as it doesn't make sense to
download additional ones when the first one is stick for some reason.