### PR TITLE
Avoid holding write transaction lock while accessing fork-join pool

### DIFF
--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/rrdp/RrdpServiceImplTest.java
@@ -99,7 +99,7 @@ public class RrdpServiceImplTest extends GenericStorageTest {
                 (snapshotInfo) -> {
                 },
                 (snapshotObject) -> {
-                    wtx0(tx -> subject.storeSnapshotObjects(tx, Collections.singletonList(snapshotObject), validationRun));
+                    subject.storeSnapshotObjects(Collections.singletonList(snapshotObject), validationRun);
                 }
         );
 


### PR DESCRIPTION
The write transaction wasn't needed in this case until all objects
were converted anyway.

Holding the write transaction lock could result in a deadlock if the
common fork-join pool is full of blocked threads (shouldn't happen...)
waiting for Xodus (read or write).

In general we should avoid accessing Xodus from the common fork-join
pool, this should also avoid this issue completely.