### PR TITLE
Notify fork join pool of blocking operations

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/ForkJoin.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/ForkJoin.java
@@ -1,3 +1,32 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 package net.ripe.rpki.validator3.util;
 
 import java.util.concurrent.ForkJoinPool;

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/ForkJoin.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/ForkJoin.java
@@ -1,0 +1,38 @@
+package net.ripe.rpki.validator3.util;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class ForkJoin {
+    /**
+     * Indicates that supplier is potentially blocking so {@link ForkJoinPool} can spawn additional threads if needed.
+     *
+     * @param supplier potentially blocking operation
+     * @param <T>      type of result
+     * @return result of Supplier#get
+     * @see ForkJoinPool#managedBlock
+     */
+    public static <T> T blocking(Supplier<T> supplier) {
+        AtomicReference<T> result = new AtomicReference<>();
+        try {
+            ForkJoinPool.managedBlock(new ForkJoinPool.ManagedBlocker() {
+                @Override
+                public boolean block() {
+                    result.set(supplier.get());
+                    return true;
+                }
+
+                @Override
+                public boolean isReleasable() {
+                    return false;
+                }
+            });
+        } catch (InterruptedException e) {
+            // We're not throwing an InterruptedException, and neither is ForkJoinPool#managedBlock,
+            // so this shouldn't happen.
+            throw new RuntimeException(e);
+        }
+        return result.get();
+    }
+}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/HttpStreaming.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/HttpStreaming.java
@@ -52,6 +52,10 @@ public class HttpStreaming {
     }
 
     public static <T> T readStream(final Supplier<Request> requestF, BiFunction<InputStream, Long,  T> reader) {
+        return ForkJoin.blocking(() -> doReadStream(requestF, reader));
+    }
+
+    private static <T> T doReadStream(Supplier<Request> requestF, BiFunction<InputStream, Long, T> reader) {
         InputStreamResponseListener listener = new InputStreamResponseListener();
 
         Request request = requestF.get();


### PR DESCRIPTION
Xodus transactions and HTTP downloads are (potentially) blocking. If
we accidentally call these from the fork join pool it may cause the
pool to be exhausted. By using the `ForkJoinPool#managedBlock` API
additional threads will be created if needed.