### PR TITLE
RPKI repository cleanup job

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/trustanchors/TrustAnchorService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/api/trustanchors/TrustAnchorService.java
@@ -36,8 +36,6 @@ import net.ripe.rpki.validator3.domain.validation.TrustAnchorState;
 import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
 import net.ripe.rpki.validator3.storage.Tx;
 import net.ripe.rpki.validator3.storage.data.Key;
-import net.ripe.rpki.validator3.storage.data.Ref;
-import net.ripe.rpki.validator3.storage.data.RpkiRepository;
 import net.ripe.rpki.validator3.storage.data.TrustAnchor;
 import net.ripe.rpki.validator3.storage.Storage;
 import net.ripe.rpki.validator3.storage.stores.RpkiRepositories;
@@ -103,12 +101,6 @@ public class TrustAnchorService {
 
     long add(Tx.Write tx, TrustAnchor trustAnchor) {
         trustAnchors.add(tx, trustAnchor);
-
-        final Ref<TrustAnchor> trustAnchorRef = trustAnchors.makeRef(tx, trustAnchor.key());
-        if (trustAnchor.getRsyncPrefetchUri() != null) {
-            rpkiRepositories.register(tx, trustAnchorRef,
-                    trustAnchor.getRsyncPrefetchUri(), RpkiRepository.Type.RSYNC_PREFETCH);
-        }
         tx.afterCommit(() -> validationScheduler.addTrustAnchor(trustAnchor));
         log.info("Added trust anchor '{}'", trustAnchor);
         return trustAnchor.key().asLong();

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/BackgroundJobs.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/BackgroundJobs.java
@@ -84,8 +84,12 @@ public class BackgroundJobs extends JobListenerSupport {
                 futureDate(3, MINUTE),
                 simpleSchedule().repeatForever().withIntervalInMinutes(10));
 
-        schedule(ValidationRunCleanupJob.class,
+        schedule(RpkiRepositoryCleanupJob.class,
                 futureDate(4, MINUTE),
+                simpleSchedule().repeatForever().withIntervalInMinutes(60));
+
+        schedule(ValidationRunCleanupJob.class,
+                futureDate(5, MINUTE),
                 simpleSchedule().repeatForever().withIntervalInMinutes(5));
 
         schedule(ValidateRsyncRepositoriesJob.class,

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/RpkiRepositoryCleanupJob.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/RpkiRepositoryCleanupJob.java
@@ -1,0 +1,53 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.rpki.validator3.background;
+
+import net.ripe.rpki.validator3.domain.cleanup.RpkiRepositoryCleanupService;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisallowConcurrentExecution
+class RpkiRepositoryCleanupJob implements Job {
+
+    @Autowired
+    private RpkiRepositoryCleanupService rpkiRepositoryCleanupService;
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        try {
+            rpkiRepositoryCleanupService.cleanupRpkiRepositories();
+        } catch (Exception e) {
+            throw new JobExecutionException(e);
+        }
+    }
+}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/ValidationScheduler.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/ValidationScheduler.java
@@ -156,7 +156,7 @@ public class ValidationScheduler {
         }
     }
 
-    public void removeRpkiRepository(RpkiRepository repository) {
+    public void removeRrdpRpkiRepository(RpkiRepository repository) {
         if (!enabled) {
             return;
         }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/cleanup/RpkiRepositoryCleanupService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/cleanup/RpkiRepositoryCleanupService.java
@@ -1,0 +1,71 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.rpki.validator3.domain.cleanup;
+
+import lombok.extern.slf4j.Slf4j;
+import net.ripe.rpki.validator3.api.util.InstantWithoutNanos;
+import net.ripe.rpki.validator3.storage.Storage;
+import net.ripe.rpki.validator3.storage.stores.RpkiObjects;
+import net.ripe.rpki.validator3.storage.stores.RpkiRepositories;
+import net.ripe.rpki.validator3.util.Time;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@Slf4j
+public class RpkiRepositoryCleanupService {
+
+    @Autowired
+    private RpkiRepositories rpkiRepositories;
+
+    private final Duration cleanupGraceDuration;
+
+    private final Storage storage;
+
+
+    public RpkiRepositoryCleanupService(@Value("${rpki.validator.rpki.repository.cleanup.grace.duration}") String cleanupGraceDuration,
+                                        Storage storage) {
+        this.cleanupGraceDuration = Duration.parse(cleanupGraceDuration);
+        log.info("Configured to remove repositories older than {}", cleanupGraceDuration);
+        this.storage = storage;
+    }
+
+    public long cleanupRpkiRepositories() {
+        final InstantWithoutNanos unreferencedSince = InstantWithoutNanos.now().minus(cleanupGraceDuration);
+        final Pair<Long, Long> deleted = Time.timed(() -> storage.writeTx(tx -> rpkiRepositories.deleteUnreferencedRepositories(tx, unreferencedSince)));
+        log.info("Removed {} RPKI repositories that have not been referenced since {}, took {}ms", deleted.getLeft(), unreferencedSince, deleted.getRight());
+        return deleted.getLeft();
+    }
+
+}

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/cleanup/RpkiRepositoryCleanupService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/cleanup/RpkiRepositoryCleanupService.java
@@ -53,11 +53,12 @@ public class RpkiRepositoryCleanupService {
 
     private final Storage storage;
 
-
-    public RpkiRepositoryCleanupService(@Value("${rpki.validator.rpki.repository.cleanup.grace.duration}") String cleanupGraceDuration,
-                                        Storage storage) {
-        this.cleanupGraceDuration = Duration.parse(cleanupGraceDuration);
+    public RpkiRepositoryCleanupService(
+            @Value("${rpki.validator.rpki.repository.cleanup.grace.duration:P7D}") Duration cleanupGraceDuration,
+            Storage storage
+    ) {
         log.info("Configured to remove repositories older than {}", cleanupGraceDuration);
+        this.cleanupGraceDuration = cleanupGraceDuration;
         this.storage = storage;
     }
 
@@ -67,5 +68,4 @@ public class RpkiRepositoryCleanupService {
         log.info("Removed {} RPKI repositories that have not been referenced since {}, took {}ms", deleted.getLeft(), unreferencedSince, deleted.getRight());
         return deleted.getLeft();
     }
-
 }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
@@ -181,7 +181,7 @@ public class RpkiRepositoryValidationService {
         } finally {
             if (triggerCaTreeAfter && changedAtLeastOneObject) {
                 storage.readTx0(tx ->
-                    rpkiRepository.getTrustAnchors().forEach(taRef ->
+                    rpkiRepository.getTrustAnchors().keySet().forEach(taRef ->
                         trustAnchors.get(tx, taRef.key()).ifPresent(trustAnchorState::setUnknown)));
             }
             storage.writeTx0(tx -> {
@@ -190,7 +190,7 @@ public class RpkiRepositoryValidationService {
             });
             if (triggerCaTreeAfter && changedAtLeastOneObject) {
                 storage.readTx0(tx ->
-                    rpkiRepository.getTrustAnchors().forEach(taRef ->
+                    rpkiRepository.getTrustAnchors().keySet().forEach(taRef ->
                         trustAnchors.get(tx, taRef.key())
                             .ifPresent(validationScheduler::triggerCertificateTreeValidation)));
             }
@@ -270,7 +270,7 @@ public class RpkiRepositoryValidationService {
                 });
             }
             storage.readTx0(tx ->
-                repository.getTrustAnchors().forEach(taRef ->
+                repository.getTrustAnchors().keySet().forEach(taRef ->
                     trustAnchors.get(tx, taRef.key()).ifPresent(affectedTrustAnchors::add)));
         }
         return affectedTrustAnchors;
@@ -314,7 +314,7 @@ public class RpkiRepositoryValidationService {
         }
 
         storage.readTx0(tx ->
-            repository.getTrustAnchors().forEach(taRef ->
+            repository.getTrustAnchors().keySet().forEach(taRef ->
                 trustAnchors.get(tx, taRef.key()).ifPresent(ta -> {
                     trustAnchorState.setUnknown(ta);
                     affectedTrustAnchors.add(ta);

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
@@ -330,7 +330,7 @@ public class RpkiRepositoryValidationService {
         for (URI parentLocation : Rsync.generateCandidateParentUris(location)) {
             RpkiRepository parentRepository = fetchedLocations.get(parentLocation);
             if (parentRepository != null && parentRepository.isDownloaded()) {
-                log.debug("Already fetched {} as part of {}, skipping", repository.getLocationUri(), parentRepository.getLocationUri());
+                log.trace("Already fetched {} as part of {}, skipping", repository.getLocationUri(), parentRepository.getLocationUri());
                 repository.setDownloaded(parentRepository.getLastDownloadedAt());
                 return parentRepository;
             }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
@@ -74,6 +74,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -214,7 +215,9 @@ public class RpkiRepositoryValidationService {
                         fetchedLocations.put(URI.create(repository.getRsyncRepositoryUri()), repository);
                     }
                     return needsUpdate;
-                });
+                })
+                // Sort repositories by location URI so that parents are processed before children
+                .sorted(Comparator.comparing((RpkiRepository r) -> URI.create(r.getRsyncRepositoryUri()).normalize()));
 
             ValidationResult results = repositoriesNeedingUpdate.map(repository -> {
                     storage.writeTx0(tx -> validationRuns.associate(tx, validationRun, repository));

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/RpkiRepositoryValidationService.java
@@ -329,14 +329,10 @@ public class RpkiRepositoryValidationService {
         URI location = URI.create(repository.getRsyncRepositoryUri());
         for (URI parentLocation : Rsync.generateCandidateParentUris(location)) {
             RpkiRepository parentRepository = fetchedLocations.get(parentLocation);
-            if (parentRepository != null) {
-                final Ref<RpkiRepository> rpkiRepositoryRef = storage.readTx(tx -> rpkiRepositories.makeRef(tx, parentRepository.key()));
-                repository.setParentRepository(rpkiRepositoryRef);
-                if (parentRepository.isDownloaded()) {
-                    log.debug("Already fetched {} as part of {}, skipping", repository.getLocationUri(), parentRepository.getLocationUri());
-                    repository.setDownloaded(parentRepository.getLastDownloadedAt());
-                    return parentRepository;
-                }
+            if (parentRepository != null && parentRepository.isDownloaded()) {
+                log.debug("Already fetched {} as part of {}, skipping", repository.getLocationUri(), parentRepository.getLocationUri());
+                repository.setDownloaded(parentRepository.getLastDownloadedAt());
+                return parentRepository;
             }
         }
         return null;

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorState.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorState.java
@@ -67,9 +67,11 @@ public class TrustAnchorState {
     }
 
     private void setState(TrustAnchor ta, State state) {
-        log.debug("Setting TA {} to {}", ta.getName(), state);
         synchronized (states) {
-            states.put(ta.getName(), state);
+            State previousState = states.put(ta.getName(), state);
+            if (state != previousState) {
+                log.debug("Setting TA {} to {}", ta.getName(), state);
+            }
         }
     }
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/TrustAnchorValidationService.java
@@ -48,6 +48,7 @@ import net.ripe.rpki.validator3.storage.Storage;
 import net.ripe.rpki.validator3.storage.data.Key;
 import net.ripe.rpki.validator3.storage.data.Ref;
 import net.ripe.rpki.validator3.storage.data.RpkiObject;
+import net.ripe.rpki.validator3.storage.data.RpkiRepository;
 import net.ripe.rpki.validator3.storage.data.TrustAnchor;
 import net.ripe.rpki.validator3.storage.data.validation.TrustAnchorValidationRun;
 import net.ripe.rpki.validator3.storage.data.validation.ValidationCheck;
@@ -141,6 +142,14 @@ public class TrustAnchorValidationService {
             if (validationResult.hasFailures()) {
                 log.warn("Validation result for the TA {} has failures: {}", trustAnchor.getName(),
                         validationResult.getFailuresForAllLocations());
+            }
+
+            if (trustAnchor.getRsyncPrefetchUri() != null) {
+                storage.writeTx0(tx -> {
+                    final Ref<TrustAnchor> trustAnchorRef = trustAnchors.makeRef(tx, trustAnchor.key());
+                    rpkiRepositories.register(tx, trustAnchorRef,
+                            trustAnchor.getRsyncPrefetchUri(), RpkiRepository.Type.RSYNC_PREFETCH);
+                });
             }
 
             validationRun.completeWith(validationResult);

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiRepository.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiRepository.java
@@ -69,11 +69,15 @@ public class RpkiRepository extends Base<RpkiRepository> {
     private InstantWithoutNanos lastDownloadedAt;
 
     /**
-     * Trust anchors that referenced this repository and need to be re-validated when new information is downloaded.
-     * For each trust anchor we store the last time the trust anchor referenced this repository.
+     * The set of trust anchors that referenced this repository during validation. Whenever this RPKI repository
+     * is updated re-validation for this set of trust anchors will be triggered. Normally a repository is only
+     * referenced by a single trust anchor, but this is not guaranteed.
      *
-     * After a grace period trust anchors will be removed from this map if they no longer reference this repository.
-     * When a repository is no longer referenced by any trust anchor it will be removed and no longer downloaded
+     * For each trust anchor we store the last time the trust anchor referenced this repository during validation.
+     * When a trust anchor no longer references a this repository during validation it will be removed from this
+     * set. This way the trust anchor will no longer be re-validated when this repository is updated.
+     *
+     * When the repository is no longer referenced by any trust anchor it will be removed and no longer updated
      * periodically.
      */
     @NotEmpty

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiRepository.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiRepository.java
@@ -80,8 +80,6 @@ public class RpkiRepository extends Base<RpkiRepository> {
 
     private BigInteger rrdpSerial;
 
-    private Ref<RpkiRepository> parentRepository;
-
     public RpkiRepository() {
     }
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiRepository.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/data/RpkiRepository.java
@@ -67,6 +67,11 @@ public class RpkiRepository extends Base<RpkiRepository> {
 
     private InstantWithoutNanos lastDownloadedAt;
 
+    /**
+     * Time when this repository was last referenced by a trust anchor or certificate tree validation run.
+     */
+    private InstantWithoutNanos lastReferencedAt;
+
     @NotEmpty
     private Set<Ref<TrustAnchor>> trustAnchors = new HashSet<>();
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/encoding/custom/RpkiRepositoryCoder.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/encoding/custom/RpkiRepositoryCoder.java
@@ -66,7 +66,6 @@ public class RpkiRepositoryCoder implements Coder<RpkiRepository> {
         encoded.appendNotNull(RRDP_SESSION, rpkiRepository.getRrdpSessionId(), Coders::toBytes);
         encoded.appendNotNull(RRDP_SERIAL, rpkiRepository.getRrdpSerial(), Coders::toBytes);
         encoded.appendNotNull(LAST_DOWNLOADED, rpkiRepository.getLastDownloadedAt(), Coders::toBytes);
-        encoded.appendNotNull(PARENT_REPOSITORY, rpkiRepository.getParentRepository(), repoRefCoder::toBytes);
 
         if (rpkiRepository.getTrustAnchors() != null && !rpkiRepository.getTrustAnchors().isEmpty()) {
             byte[] taBytes = Coders.toBytes(rpkiRepository.getTrustAnchors(), taRefCoder::toBytes);
@@ -90,7 +89,6 @@ public class RpkiRepositoryCoder implements Coder<RpkiRepository> {
         Encoded.field(content, RRDP_SESSION).ifPresent(b -> rpkiRepository.setRrdpSessionId(Coders.toString(b)));
         Encoded.field(content, RRDP_SERIAL).ifPresent(b -> rpkiRepository.setRrdpSerial(Coders.toBigInteger(b)));
         Encoded.field(content, LAST_DOWNLOADED).ifPresent(b -> rpkiRepository.setLastDownloadedAt(Coders.toInstant(b)));
-        Encoded.field(content, PARENT_REPOSITORY).ifPresent(b -> rpkiRepository.setParentRepository(repoRefCoder.fromBytes(b)));
 
         Encoded.field(content, TRUST_ANCHORS).ifPresent(b -> {
             final List<Ref<TrustAnchor>> objects = Coders.fromBytes(b, taRefCoder::fromBytes);

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/encoding/custom/RpkiRepositoryCoder.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/encoding/custom/RpkiRepositoryCoder.java
@@ -49,6 +49,7 @@ public class RpkiRepositoryCoder implements Coder<RpkiRepository> {
     private final static short LAST_DOWNLOADED = Tags.unique(57);
     private final static short PARENT_REPOSITORY = Tags.unique(58);
     private final static short TRUST_ANCHORS = Tags.unique(59);
+    private final static short LAST_REFERENCED = Tags.unique(60);
 
     private final static RefCoder<RpkiRepository> repoRefCoder = new RefCoder<>();
     private final static RefCoder<TrustAnchor> taRefCoder = new RefCoder<>();
@@ -66,6 +67,7 @@ public class RpkiRepositoryCoder implements Coder<RpkiRepository> {
         encoded.appendNotNull(RRDP_SESSION, rpkiRepository.getRrdpSessionId(), Coders::toBytes);
         encoded.appendNotNull(RRDP_SERIAL, rpkiRepository.getRrdpSerial(), Coders::toBytes);
         encoded.appendNotNull(LAST_DOWNLOADED, rpkiRepository.getLastDownloadedAt(), Coders::toBytes);
+        encoded.appendNotNull(LAST_REFERENCED, rpkiRepository.getLastReferencedAt(), Coders::toBytes);
 
         if (rpkiRepository.getTrustAnchors() != null && !rpkiRepository.getTrustAnchors().isEmpty()) {
             byte[] taBytes = Coders.toBytes(rpkiRepository.getTrustAnchors(), taRefCoder::toBytes);
@@ -89,6 +91,7 @@ public class RpkiRepositoryCoder implements Coder<RpkiRepository> {
         Encoded.field(content, RRDP_SESSION).ifPresent(b -> rpkiRepository.setRrdpSessionId(Coders.toString(b)));
         Encoded.field(content, RRDP_SERIAL).ifPresent(b -> rpkiRepository.setRrdpSerial(Coders.toBigInteger(b)));
         Encoded.field(content, LAST_DOWNLOADED).ifPresent(b -> rpkiRepository.setLastDownloadedAt(Coders.toInstant(b)));
+        Encoded.field(content, LAST_REFERENCED).ifPresent(b -> rpkiRepository.setLastReferencedAt(Coders.toInstant(b)));
 
         Encoded.field(content, TRUST_ANCHORS).ifPresent(b -> {
             final List<Ref<TrustAnchor>> objects = Coders.fromBytes(b, taRefCoder::fromBytes);

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/stores/RpkiRepositories.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/stores/RpkiRepositories.java
@@ -32,6 +32,7 @@ package net.ripe.rpki.validator3.storage.stores;
 import net.ripe.rpki.validator3.api.Paging;
 import net.ripe.rpki.validator3.api.SearchTerm;
 import net.ripe.rpki.validator3.api.Sorting;
+import net.ripe.rpki.validator3.api.util.InstantWithoutNanos;
 import net.ripe.rpki.validator3.storage.Tx;
 import net.ripe.rpki.validator3.storage.data.Key;
 import net.ripe.rpki.validator3.storage.data.Ref;
@@ -77,4 +78,6 @@ public interface RpkiRepositories extends GenericStore<RpkiRepository> {
     void remove(Tx.Write tx, Key key);
 
     Collection<RpkiRepository> findByTrustAnchor(Tx.Read tx, Key key);
+
+    long deleteUnreferencedRepositories(Tx.Write tx, InstantWithoutNanos unreferencedSince);
 }

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/stores/impl/RpkiRepositoriesStore.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/stores/impl/RpkiRepositoriesStore.java
@@ -340,6 +340,9 @@ public class RpkiRepositoriesStore extends GenericStoreImpl<RpkiRepository> impl
                     if (trustAnchors.isEmpty()) {
                         log.info("removing RPKI repository {} (unreferenced since {})", rpkiRepository.getLocationUri(), unreferencedSince);
                         if (rpkiRepository.getType() == RpkiRepository.Type.RRDP) {
+                            // RRDP jobs are scheduled separately for each repository, remove from scheduling
+                            // before deletion. RSYNC repositories are managed by a single background job, so
+                            // no special action needed.
                             tx.afterCommit(() -> validationScheduler.removeRrdpRpkiRepository(rpkiRepository));
                         }
                         ixMap.delete(tx, rpkiRepository.key());

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/stores/impl/RpkiRepositoriesStore.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/stores/impl/RpkiRepositoriesStore.java
@@ -29,6 +29,7 @@
  */
 package net.ripe.rpki.validator3.storage.stores.impl;
 
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
 import net.ripe.rpki.validator3.api.Paging;
@@ -56,11 +57,13 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -87,7 +90,7 @@ public class RpkiRepositoriesStore extends GenericStoreImpl<RpkiRepository> impl
                 RPKI_REPOSITORIES,
                 ImmutableMap.of(
                         BY_URI_PREFIX, this::locationIndex,
-                        BY_TA, r -> r.getTrustAnchors().stream().map(Ref::key).collect(Collectors.toSet())
+                        BY_TA, r -> r.getTrustAnchors().keySet().stream().map(Ref::key).collect(Collectors.toSet())
                 ),
                 RpkiRepository.class
         );
@@ -119,8 +122,6 @@ public class RpkiRepositoriesStore extends GenericStoreImpl<RpkiRepository> impl
             final Key primaryKey = Key.of(sequences.next(tx, RPKI_REPOSITORIES + ":pk"));
             registered.setId(primaryKey);
         }
-
-        registered.setLastReferencedAt(InstantWithoutNanos.now());
 
         if (type == RpkiRepository.Type.RSYNC && registered.getType() == RpkiRepository.Type.RSYNC_PREFETCH) {
             registered.setType(RpkiRepository.Type.RSYNC);
@@ -296,7 +297,7 @@ public class RpkiRepositoriesStore extends GenericStoreImpl<RpkiRepository> impl
                     rpkiRepository.removeTrustAnchor(taRef);
                     if (rpkiRepository.getTrustAnchors().isEmpty()) {
                         if (rpkiRepository.getType() == RpkiRepository.Type.RRDP) {
-                            tx.afterCommit(() -> validationScheduler.removeRpkiRepository(rpkiRepository));
+                            tx.afterCommit(() -> validationScheduler.removeRrdpRpkiRepository(rpkiRepository));
                         }
                         ixMap.delete(tx, pk);
                     } else {
@@ -313,6 +314,42 @@ public class RpkiRepositoriesStore extends GenericStoreImpl<RpkiRepository> impl
     @Override
     public Collection<RpkiRepository> findByTrustAnchor(Tx.Read tx, Key key) {
         return ixMap.getByIndex(BY_TA, tx, key).values();
+    }
+
+    @Override
+    public long deleteUnreferencedRepositories(Tx.Write tx, InstantWithoutNanos unreferencedSince) {
+        Stream<RpkiRepository> repositories = findRepositoriesByPredicate(tx, Predicates.alwaysTrue());
+        AtomicLong counter = new AtomicLong(0);
+
+        repositories
+                .sorted(Comparator.comparing(RpkiRepository::getLocationUri).reversed())
+                .forEach(rpkiRepository -> {
+                    Map<Ref<TrustAnchor>, InstantWithoutNanos> trustAnchors = rpkiRepository.getTrustAnchors();
+
+                    boolean updated = false;
+                    Iterator<Map.Entry<Ref<TrustAnchor>, InstantWithoutNanos>> it = trustAnchors.entrySet().iterator();
+                    while (it.hasNext()) {
+                        Map.Entry<Ref<TrustAnchor>, InstantWithoutNanos> pair = it.next();
+                        InstantWithoutNanos lastReferencedAt = pair.getValue();
+                        if (lastReferencedAt.isBefore(unreferencedSince)) {
+                            it.remove();
+                            updated = true;
+                        }
+                    }
+
+                    if (trustAnchors.isEmpty()) {
+                        log.info("removing RPKI repository {} (unreferenced since {})", rpkiRepository.getLocationUri(), unreferencedSince);
+                        if (rpkiRepository.getType() == RpkiRepository.Type.RRDP) {
+                            tx.afterCommit(() -> validationScheduler.removeRrdpRpkiRepository(rpkiRepository));
+                        }
+                        ixMap.delete(tx, rpkiRepository.key());
+
+                        counter.incrementAndGet();
+                    } else if (updated) {
+                        update(tx, rpkiRepository);
+                    }
+                });
+        return counter.get();
     }
 
     @Override

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/stores/impl/RpkiRepositoriesStore.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/stores/impl/RpkiRepositoriesStore.java
@@ -120,6 +120,8 @@ public class RpkiRepositoriesStore extends GenericStoreImpl<RpkiRepository> impl
             registered.setId(primaryKey);
         }
 
+        registered.setLastReferencedAt(InstantWithoutNanos.now());
+
         if (type == RpkiRepository.Type.RSYNC && registered.getType() == RpkiRepository.Type.RSYNC_PREFETCH) {
             registered.setType(RpkiRepository.Type.RSYNC);
         }

--- a/rpki-validator/src/main/resources/application.properties
+++ b/rpki-validator/src/main/resources/application.properties
@@ -59,6 +59,7 @@ rpki.validator.rsync.repository.download.interval=PT10M
 rpki.validator.rrdp.trust.all.tls.certificates=false
 
 rpki.validator.rpki.object.cleanup.grace.duration=P7D
+rpki.validator.rpki.repository.cleanup.grace.duration=P7D
 
 rpki.validator.validation.run.cleanup.grace.duration=PT6H
 

--- a/rpki-validator/src/main/resources/packaging/deb/etc/rpki-validator-3/application.properties
+++ b/rpki-validator/src/main/resources/packaging/deb/etc/rpki-validator-3/application.properties
@@ -103,6 +103,7 @@ rpki.validator.rsync.repository.download.interval=PT10M
 rpki.validator.rrdp.trust.all.tls.certificates=false
 
 rpki.validator.rpki.object.cleanup.grace.duration=P7D
+rpki.validator.rpki.repository.cleanup.grace.duration=P7D
 
 rpki.validator.validation.run.cleanup.grace.duration=PT6H
 

--- a/rpki-validator/src/main/resources/packaging/generic/conf/application-defaults.properties
+++ b/rpki-validator/src/main/resources/packaging/generic/conf/application-defaults.properties
@@ -82,6 +82,7 @@ rpki.validator.rrdp.repository.download.interval=PT2M
 rpki.validator.rrdp.trust.all.tls.certificates=false
 
 rpki.validator.rpki.object.cleanup.grace.duration=P7D
+rpki.validator.rpki.repository.cleanup.grace.duration=P7D
 
 rpki.validator.validation.run.cleanup.grace.duration=PT6H
 

--- a/rpki-validator/src/main/resources/packaging/generic/conf/application.properties
+++ b/rpki-validator/src/main/resources/packaging/generic/conf/application.properties
@@ -95,6 +95,7 @@ rpki.validator.rsync.repository.download.interval=PT10M
 rpki.validator.rrdp.trust.all.tls.certificates=false
 
 rpki.validator.rpki.object.cleanup.grace.duration=P7D
+rpki.validator.rpki.repository.cleanup.grace.duration=P7D
 
 rpki.validator.validation.run.cleanup.grace.duration=PT6H
 

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/cleanup/RpkiRepositoryCleanupServiceTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/cleanup/RpkiRepositoryCleanupServiceTest.java
@@ -1,0 +1,86 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2018 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.rpki.validator3.domain.cleanup;
+
+import net.ripe.rpki.validator3.IntegrationTest;
+import net.ripe.rpki.validator3.TestObjects;
+import net.ripe.rpki.validator3.api.util.InstantWithoutNanos;
+import net.ripe.rpki.validator3.domain.ta.TrustAnchorsFactory;
+import net.ripe.rpki.validator3.storage.data.Ref;
+import net.ripe.rpki.validator3.storage.data.RpkiRepository;
+import net.ripe.rpki.validator3.storage.data.TrustAnchor;
+import net.ripe.rpki.validator3.storage.stores.RpkiRepositories;
+import net.ripe.rpki.validator3.storage.stores.impl.GenericStorageTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.ZonedDateTime;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(SpringRunner.class)
+@IntegrationTest
+public class RpkiRepositoryCleanupServiceTest extends GenericStorageTest {
+
+    @Autowired
+    private TrustAnchorsFactory factory;
+
+    @Autowired
+    private RpkiRepositoryCleanupService subject;
+
+    @Autowired
+    private RpkiRepositories rpkiRepositories;
+
+    @Test
+    public void should_delete_repositories_not_referenced_during_validation() throws Exception {
+        TrustAnchor trustAnchor = TestObjects.newTrustAnchor();
+        wtx0(tx -> this.getTrustAnchors().add(tx, trustAnchor));
+
+        final Ref<TrustAnchor> trustAnchorRef = rtx(tx -> this.getTrustAnchors().makeRef(tx, trustAnchor.key()));
+        RpkiRepository repository = wtx(tx -> this.getRpkiRepositories().register(tx,
+                trustAnchorRef, "rsync://some.rsync.repo", RpkiRepository.Type.RSYNC));
+
+        assertThat(rtx(tx -> rpkiRepositories.findRsyncRepositories(tx).collect(Collectors.toList())), hasSize(1));
+        assertThat(subject.cleanupRpkiRepositories(), is(0L));
+
+        repository.getTrustAnchors().put(trustAnchorRef, InstantWithoutNanos.from(ZonedDateTime.now().minusDays(20).toInstant()));
+        wtx0(tx -> rpkiRepositories.update(tx, repository));
+
+        assertThat(subject.cleanupRpkiRepositories(), is(1L));
+
+        assertThat(rtx(tx -> rpkiRepositories.findRsyncRepositories(tx).collect(Collectors.toList())), is(empty()));
+    }
+}

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/encoding/custom/RpkiRepositoryCoderTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/storage/encoding/custom/RpkiRepositoryCoderTest.java
@@ -46,8 +46,6 @@ public class RpkiRepositoryCoderTest {
     public void testSaveRead() {
         Ref<TrustAnchor> trustAnchorRef = Ref.unsafe("bla", Key.of(123L));
         RpkiRepository rpkiRepository = new RpkiRepository(trustAnchorRef, "some-uri", RpkiRepository.Type.RRDP);
-        Ref<RpkiRepository> parentRepoRef = Ref.unsafe("foo", Key.of(987654321L));
-        rpkiRepository.setParentRepository(parentRepoRef);
         rpkiRepository.setLastDownloadedAt(InstantWithoutNanos.now());
         rpkiRepository.setRrdpSerial(new BigInteger("2133553334897396402696204629648763485348763845"));
         rpkiRepository.setRrdpSessionId("sfjbkskbsfkbjsfkjbs");


### PR DESCRIPTION
Track the time that a repository was last referenced during a validation run. Once a repository hasn't been referenced for at least `rpki.validator.rpki.repository.cleanup.grace.duration` it will be deleted. Deleted RRDP repositories will also be removed from the validation scheduler.

Best way to review is probably by going through each commit separately.