### PR TITLE
Maximize managed blocker threads

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationService.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationService.java
@@ -337,9 +337,9 @@ public class CertificateTreeValidationService {
             }
             accumulator.add(manifestObject.get().key(), manifest, ImmutableSortedSet.of(temporary.getCurrentLocation().getName()));
 
-            manifest.getFiles().entrySet()
-                .parallelStream()
+            manifest.getFiles().entrySet().stream()
                 .flatMap(entry -> getManifestEntry(manifestUri, entry))
+                .parallel()
                 .flatMap(tuple -> getCertificateRepositoryObjectValidationContext(trustAnchor, context, accumulator, crlUri, x509Crl, tuple))
                 .map(tuple -> {
                     final ValidationResult vr = tuple.v2();

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/xodus/Xodus.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/storage/xodus/Xodus.java
@@ -113,16 +113,14 @@ public abstract class Xodus implements Storage {
 
     public <T> T readTx(Function<Tx.Read, T> f) {
         Environment env = getEnv();
-        return ForkJoin.blocking(() -> {
-            return env.computeInReadonlyTransaction(txn -> {
-                XodusTx.Read tx = XodusTx.fromRONative(env, txn);
-                txs.put(tx.getId(), new TxInfo(tx));
-                try {
-                    return f.apply(tx);
-                } finally {
-                    txs.remove(tx.getId());
-                }
-            });
+        return env.computeInReadonlyTransaction(txn -> {
+            XodusTx.Read tx = XodusTx.fromRONative(env, txn);
+            txs.put(tx.getId(), new TxInfo(tx));
+            try {
+                return f.apply(tx);
+            } finally {
+                txs.remove(tx.getId());
+            }
         });
     }
 

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/ForkJoin.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/util/ForkJoin.java
@@ -42,9 +42,14 @@ public class ForkJoin {
     private static final Semaphore maximumManagedBlockers;
 
     static {
+        // The default maximumSpares used by the common fork-join pool
         int maximumSpares = Integer.parseInt(System.getProperty("java.util.concurrent.ForkJoinPool.common.maximumSpares", "256"));
+
+        // The number of additional concurrent threads we want to use up. We do not want to use all the maximumSpares,
+        // since other parts or libraries may also use a few and we really want to avoid `RejectedEcecutionExceptions`.
+        // Furthermore, using a large number of additional threads is probably not optimal anyway.
         int max = Math.min(2 * ForkJoinPool.getCommonPoolParallelism(), maximumSpares / 4);
-        log.info("maximum concurrent blocking threads for common fork-join pool is {}", max);
+        log.info("maximum additional concurrent blocking threads for common fork-join pool is {}", max);
         maximumManagedBlockers = new Semaphore(max);
     }
 


### PR DESCRIPTION
Ensures we no longer take up all the spare threads in the common fork-join pool that can cause `RejectedExecutionExceptions`. 

I'm not sure of all this is worth the trouble. The validator worked before without any `blocking` implementation so an alternative is to just remove this whole concept for simplicity.