### PR TITLE
Use depth-first CA validation to reduce memory usage

### DIFF
--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/SearchTermTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/SearchTermTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import net.ripe.ipresource.IpRange;
 import net.ripe.rpki.validator3.domain.ValidatedRoaPrefix;
 import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
+import net.ripe.rpki.validator3.storage.data.Key;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -48,7 +49,7 @@ public class SearchTermTest {
     private final ValidatedRoaPrefix asnTest = ValidatedRoaPrefix.of(null, 3642, null, 32,
             Instant.now().toEpochMilli(),Instant.now().plus(365, DAYS).toEpochMilli(), BigInteger.ONE,null);
     private final ValidatedRoaPrefix genericTest = ValidatedRoaPrefix.of(
-            ValidatedRpkiObjects.TrustAnchorData.of(1L, "Bla Anchor"),
+            ValidatedRpkiObjects.TrustAnchorData.of(Key.of(1L), "Bla Anchor"),
             3642,
             null, 32,
             Instant.now().toEpochMilli(),Instant.now().plus(365, DAYS).toEpochMilli(), BigInteger.ONE,

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/bgpsec/BgpSecFilterServiceTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/api/bgpsec/BgpSecFilterServiceTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableList;
 import net.ripe.ipresource.Asn;
 import net.ripe.rpki.validator3.IntegrationTest;
 import net.ripe.rpki.validator3.domain.validation.ValidatedRpkiObjects;
+import net.ripe.rpki.validator3.storage.data.Key;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,15 +66,15 @@ public class BgpSecFilterServiceTest {
     private static final String PK_3 = "zzzzzzz";
 
     private static final ValidatedRpkiObjects.RouterCertificate CERTIFICATE_1 = ValidatedRpkiObjects.RouterCertificate.of(
-            ValidatedRpkiObjects.TrustAnchorData.of(1L, "Test TA 1"),
+            ValidatedRpkiObjects.TrustAnchorData.of(Key.of(1L), "Test TA 1"),
             ImmutableList.of(ASN_1.toString()), SKI_1, PK_1);
 
     private static final ValidatedRpkiObjects.RouterCertificate CERTIFICATE_2 = ValidatedRpkiObjects.RouterCertificate.of(
-            ValidatedRpkiObjects.TrustAnchorData.of(2L, "Test TA 2"),
+            ValidatedRpkiObjects.TrustAnchorData.of(Key.of(2L), "Test TA 2"),
             ImmutableList.of(ASN_1.toString(), ASN_2.toString()), SKI_2, PK_2);
 
     private static final ValidatedRpkiObjects.RouterCertificate CERTIFICATE_3 = ValidatedRpkiObjects.RouterCertificate.of(
-            ValidatedRpkiObjects.TrustAnchorData.of(3L, "Test TA 3"),
+            ValidatedRpkiObjects.TrustAnchorData.of(Key.of(3L), "Test TA 3"),
             ImmutableList.of(ASN_1.toString()), SKI_3, PK_3);
 
     @Test


### PR DESCRIPTION
The code relies a bit less on side-effects and the validation
functions now return a result instead of mutating an accumulator.

All certificate authorities are validated, even when a manifest
contains errors in strict mode. However, the results of the validation
are not kept. This way we avoid having keep child certificates in
memory or to parse the manifest entries twice (first to discover
errors in the manifest, then to process the children).