### PR TITLE
Add current validator version to the UI footer.

### DIFF
--- a/ui-validator/src/app/core/footer/footer.component.html
+++ b/ui-validator/src/app/core/footer/footer.component.html
@@ -1,7 +1,7 @@
 <footer class='footer container border-top'>
   <div class='text-center'>
     <img src='assets/images/ncc-logo.png' height='24' width='99' class='px-2'/>
-    <small class='text-muted'>{{ 'Footer.COPYRIGHT' | translate}}</small>
+    <small class='text-muted'>{{ 'Footer.COPYRIGHT' | translate}} Version: {{version}}</small>
   </div>
 </footer>
 

--- a/ui-validator/src/app/core/footer/footer.component.ts
+++ b/ui-validator/src/app/core/footer/footer.component.ts
@@ -1,4 +1,6 @@
 import {Component, OnInit} from '@angular/core';
+import {HttpClient} from "@angular/common/http";
+import {IResponse} from "../../shared/response.model";
 
 @Component({
   selector: 'app-footer',
@@ -7,10 +9,16 @@ import {Component, OnInit} from '@angular/core';
 })
 export class FooterComponent implements OnInit {
 
-  constructor() {
-  }
+  version: string;
+
+  constructor(private _http: HttpClient) {}
 
   ngOnInit() {
+    this._http.get<IResponse>('/api/healthcheck', {})
+      .subscribe(
+        response => {
+          this.version = response.data.buildInformation.version
+        });
   }
 
 }

--- a/ui-validator/src/assets/i18n/en.json
+++ b/ui-validator/src/assets/i18n/en.json
@@ -64,7 +64,7 @@
     "UNKONOWN": "Please refresh page"
   },
   "Footer": {
-    "COPYRIGHT": "Copyright ©2009-2020 the Réseaux IP Européens Network Coordination Centre RIPE NCC. All rights restricted. Version: 3.1."
+    "COPYRIGHT": "Copyright ©2009-2020 the Réseaux IP Européens Network Coordination Centre RIPE NCC. All rights restricted."
   },
   "TrustAnchors": {
     "PROCESSED_ITEMS": "Processed Items",

--- a/ui-validator/src/assets/i18n/fr.json
+++ b/ui-validator/src/assets/i18n/fr.json
@@ -10,7 +10,7 @@
     "TITLE": "Quick Overview of BGP Origin Validation"
   },
   "Footer": {
-    "COPYRIGHT": "Copyright ©2009-2020 the Réseaux IP Européens Network Coordination Centre RIPE NCC. All rights restricted. Version: 3.1."
+    "COPYRIGHT": "Copyright ©2009-2020 the Réseaux IP Européens Network Coordination Centre RIPE NCC. All rights restricted."
   }
 
 }


### PR DESCRIPTION
The version is downloaded from the '/api/healthcheck' end-point.