### PR TITLE
Validate that RPKI repository object was found at the correct location

### DIFF
--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/ta/TrustAnchorsFactory.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/ta/TrustAnchorsFactory.java
@@ -87,8 +87,8 @@ public class TrustAnchorsFactory {
     private static final X509ResourceCertificate RIPE_NCC_TA_CERTIFICATE = loadCertificate("/ripe-ncc-ta.cer");
     public static final String TA_RRDP_NOTIFY_URI = "https://rpki.test/notification.xml";
     public static final String TA_CA_REPOSITORY_URI = "rsync://rpki.test/repository/";
-    private static final String TA_MANIFEST_URI = "rsync://rpki.test/test-trust-anchor.mft";
-    private static final String TA_CRL_URI = "rsync://rpki.test/test-trust-anchor.crl";
+    private static final String TA_MANIFEST_URI = TA_CA_REPOSITORY_URI + "test-trust-anchor.mft";
+    private static final String TA_CRL_URI = TA_CA_REPOSITORY_URI + "test-trust-anchor.crl";
     public static final KeyPairFactory KEY_PAIR_FACTORY = new KeyPairFactory(BouncyCastleProvider.PROVIDER_NAME);
     private static final String TA_ISSUER_DN = "CN=test";
 
@@ -197,7 +197,7 @@ public class TrustAnchorsFactory {
 
                 final RpkiObject certObject = new RpkiObject(childCertificate);
                 rpkiObjects.put(tx, certObject);
-                rpkiObjects.addLocation(tx, certObject.key(), ca.repositoryURI + "/" + child.dn + ".cer");
+                rpkiObjects.addLocation(tx, certObject.key(), ca.repositoryURI + child.dn + ".cer");
                 manifestBuilder.addFile(child.dn + ".cer", childCertificate.getEncoded());
             }
         }
@@ -234,7 +234,7 @@ public class TrustAnchorsFactory {
 
                 final RpkiObject roaObject = new RpkiObject(roaCms);
                 rpkiObjects.put(tx, roaObject);
-                rpkiObjects.addLocation(tx, roaObject.key(), ca.repositoryURI + "/" + "AS" + roaPrefix.getAsn() + ".roa");
+                rpkiObjects.addLocation(tx, roaObject.key(), ca.repositoryURI + "AS" + roaPrefix.getAsn() + ".roa");
                 manifestBuilder.addFile("AS" + roaPrefix.getAsn() + ".roa", roaCms.getEncoded());
             });
         }

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationServiceTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationServiceTest.java
@@ -193,8 +193,8 @@ public class CertificateTreeValidationServiceTest extends GenericStorageTest {
         rtx0(tx ->
                 assertEquals(
                         Sets.newHashSet(
-                                "rsync://rpki.test/test-trust-anchor.mft",
-                                "rsync://rpki.test/test-trust-anchor.crl"
+                                "rsync://rpki.test/repository/test-trust-anchor.mft",
+                                "rsync://rpki.test/repository/test-trust-anchor.crl"
                         ),
                         validatedObjects.stream()
                                 .flatMap(ro -> this.getRpkiObjects().getLocations(tx, ro.key()).stream())
@@ -215,7 +215,7 @@ public class CertificateTreeValidationServiceTest extends GenericStorageTest {
             TrustAnchorsFactory.CertificateAuthority child = TrustAnchorsFactory.CertificateAuthority.builder()
                 .dn("CN=child-ca")
                 .keyPair(childKeyPair)
-                .certificateLocation("rsync://rpki.test/CN=child-ca.cer")
+                .certificateLocation(TA_CA_REPOSITORY_URI + "CN=child-ca.cer")
                 .resources(IpResourceSet.parse("192.168.128.0/17"))
                 .notifyURI(TA_RRDP_NOTIFY_URI)
                 .manifestURI("rsync://rpki.test/CN=child-ca/child-ca.mft")


### PR DESCRIPTION
The validation is not strictly correct since the object may have
already been removed from the original location, but we will still
validate it.