### PR TITLE
Decrease bootstrap time to first validation

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/BackgroundJobs.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/BackgroundJobs.java
@@ -94,7 +94,7 @@ public class BackgroundJobs extends JobListenerSupport {
 
         schedule(ValidateRsyncRepositoriesJob.class,
                 futureDate(10, SECOND),
-                simpleSchedule().repeatForever().withIntervalInMinutes(5));
+                simpleSchedule().repeatForever().withIntervalInMinutes(1));
 
         schedule(DownloadBgpRisDumpsJob.class,
                 futureDate(10, SECOND),

--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/ValidationScheduler.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/background/ValidationScheduler.java
@@ -78,14 +78,7 @@ public class ValidationScheduler {
         this.rrpdRepositoryDownloadInterval = Duration.parse(rrpdRepositoryDownloadInterval);
         this.validationService = validationService;
 
-        // Allow tree re-validation as often as minimum repository fetch interval,
-        // but in any case not more often then once a minute.
-        final long minIntervalBetweenTreeValidationsInSeconds = Math.max(60,
-            Math.min(
-                this.rsyncRepositoryDownloadInterval.getSeconds(),
-                this.rrpdRepositoryDownloadInterval.getSeconds()));
-
-        throttledTreeValidation = new Throttled<>(minIntervalBetweenTreeValidationsInSeconds);
+        this.throttledTreeValidation = new Throttled<>(30_000);
 
         // Disable scheduling during tests
         if (environment.acceptsProfiles(Profiles.of("test"))) {


### PR DESCRIPTION
Fixes two causes of long delays in the bootstrapping process:

1. Triggering already running certificate tree validations were ignored. So if a repository was updated while a validation is already running it could take 10+ minutes before the certificate tree validation was run again, based on the frequency of repository updates. Now the trigger is remembered and the validation will be scheduled again after the current run completes. The minimum time between validation runs was also reduced, as it is mainly used to avoid quickly triggering multiple runs.

2. The database was only checked once every 5 minutes for PENDING rsync repositories. Now we check every minute.

Together these changes result in a bootstrap time between 3-4 minutes (also depending on network speed, etc) using the 5 RIR trust anchors and the AS0 trust anchor.

Note that the `Throttled` class requires careful review since it needs to be concurrency aware and safe.
