### PR TITLE
Default to strict validation

### DIFF
--- a/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ErrorCodes.java
+++ b/rpki-validator/src/main/java/net/ripe/rpki/validator3/domain/ErrorCodes.java
@@ -56,6 +56,8 @@ public class ErrorCodes {
     public static final String REPOSITORY_OBJECT_MAXIMUM_SIZE = "repository.object.maximum.size";
     public static final String REPOSITORY_OBJECT_IS_TRUST_ANCHOR_CERTIFICATE = "repository.object.is.trust.anchor.certificate";
 
+    public static final String MANIFEST_ALL_ENTRIES_VALID = "manifest.all.entries.valid";
+
     public static final String UNHANDLED_EXCEPTION = "unhandled.exception";
 
     private ErrorCodes() {

--- a/rpki-validator/src/main/resources/application.properties
+++ b/rpki-validator/src/main/resources/application.properties
@@ -93,8 +93,8 @@ management.endpoints.enabled-by-default=false
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=prometheus
 
-# Enabling strict validation will reject stale manifest, stale crls, and manifest with entries referring to non-existent objects.
-rpki.validator.strict-validation=false
+# Disabling strict validation will accept stale manifests, stale CRLs, and manifests with entries with validation errors
+rpki.validator.strict-validation=true
 
 # This disables RRDP, so the validator only uses rsync to download repositories.
 rpki.validator.rsync-only=false

--- a/rpki-validator/src/main/resources/messages.properties
+++ b/rpki-validator/src/main/resources/messages.properties
@@ -65,7 +65,7 @@ rsync.repository.io.error=Rsync repository I/O error: {0}
 
 trust.anchor.fetch.error=Trust anchor could not be loaded from {0}: {1}
 trust.anchor.fetch.warning=Trust anchor could not be loaded from {0}: {1}
-trust.acnhor.fetch.passed=Trust anchor loaded from {0}
+trust.anchor.fetch.passed=Trust anchor loaded from {0}
 
 trust.anchor.signature.error=Trust anchor certificate {0} did not match public key signature {1}
 trust.anchor.signature.passed=Trust anchor certificate {0} public key signature matches

--- a/rpki-validator/src/main/resources/messages.properties
+++ b/rpki-validator/src/main/resources/messages.properties
@@ -76,4 +76,7 @@ repository.object.maximum.size.error=RPKI object {0} size {1} is greater than th
 repository.object.is.trust.anchor.certificate.error=RPKI object {0} is not a trust anchor
 repository.object.is.trust.anchor.certificate.passed=RPKI object {0} is a trust anchor
 
+manifest.all.entries.valid.warning=Not all manifest objects are valid, all entries are rejected
+manifest.all.entries.valid.passed=All manifest objects are valid
+
 unhandled.exception.error=Unhandled exception {0}: {1}

--- a/rpki-validator/src/main/resources/packaging/generic/conf/application-defaults.properties
+++ b/rpki-validator/src/main/resources/packaging/generic/conf/application-defaults.properties
@@ -101,8 +101,8 @@ jvm.mem.initial=1024m       # -Xms jvm option -> initial memory claimed by the j
 jvm.mem.maximum=1536m       # -Xmx jvm option -> maximum memory for the jvm
 
 
-# Enabling strict validation will not allow stale manifest, stale crl, and reject manifest with entries referring to non-existent objects.
-rpki.validator.strict-validation=false
+# Disabling strict validation will accept stale manifests, stale CRLs, and manifests with entries with validation errors
+rpki.validator.strict-validation=true
 
 # This disables RRDP, so the validator only uses rsync to download repositories.
 rpki.validator.rsync-only=false


### PR DESCRIPTION
Adds a warning when a manifest is invalidated due to the presence of an invalid object.

Currently the differences between strict or non-strict is about 94 ROA prefixes using the trust anchors displayed below:

<img width="1178" alt="TAs" src="https://user-images.githubusercontent.com/159416/96596226-c6b0f600-12ec-11eb-927c-85a55417f3cf.png">

Three manifests from APNIC become invalid (from https://rpki.cnnic.cn/) and one ROA from RIPE NCC due to an elapsed manifest next update time (from rsync://rpkica.mccay.com/). 

The affected ROAs are:

> "132168","2402:1440::/32","48","APNIC RPKI Root","2020-10-13T14:05:00Z","2021-04-29T06:55:15Z","1236"
> "13444","103.221.92.0/22","24","APNIC RPKI Root","2020-05-09T08:36:19Z","2021-04-29T06:55:15Z","2622"
> "138527","103.221.16.0/22","24","APNIC RPKI Root","2020-07-13T10:44:09Z","2021-04-29T06:55:15Z","2986"
> "138527","103.221.20.0/22","24","APNIC RPKI Root","2020-07-13T10:44:09Z","2021-04-29T06:55:15Z","2986"
> "138527","103.221.24.0/22","24","APNIC RPKI Root","2020-07-13T10:44:09Z","2021-04-29T06:55:15Z","2986"
> "138527","103.221.28.0/22","24","APNIC RPKI Root","2020-07-13T10:44:09Z","2021-04-29T06:55:15Z","2986"
> "138527","103.221.36.0/22","24","APNIC RPKI Root","2020-07-13T10:44:09Z","2021-04-29T06:55:15Z","2986"
> "138527","103.221.40.0/22","24","APNIC RPKI Root","2020-07-13T10:44:09Z","2021-04-29T06:55:15Z","2986"
> "138527","103.221.44.0/22","24","APNIC RPKI Root","2020-07-13T10:44:09Z","2021-04-29T06:55:15Z","2986"
> "138527","103.221.92.0/22","24","APNIC RPKI Root","2020-07-13T10:44:09Z","2021-04-29T06:55:15Z","2986"
> "138571","103.198.216.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.198.220.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.198.224.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.198.228.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.198.232.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.198.236.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.198.244.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.220.248.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.6.108.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "138571","103.6.228.0/22","24","APNIC RPKI Root","2020-05-09T07:56:24Z","2021-04-29T06:55:15Z","2486"
> "139076","103.221.32.0/22","24","APNIC RPKI Root","2020-05-09T07:46:43Z","2021-04-29T06:55:15Z","2428"
> "139076","103.221.48.0/22","24","APNIC RPKI Root","2020-05-09T07:46:43Z","2021-04-29T06:55:15Z","2428"
> "17621","103.24.116.0/24","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2742"
> "17621","103.24.118.0/23","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2742"
> "17621","103.5.192.0/22","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2742"
> "17621","150.242.238.0/23","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2742"
> "17621","202.89.96.0/24","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2742"
> "17621","43.254.152.0/24","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2742"
> "210089","2001:67c:1190::/48","48","RIPE NCC RPKI Root","2020-07-04T12:55:55Z","2021-07-04T13:00:55Z","341790416367478271309766930347671808605580544225"
> "24373","103.220.252.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.16.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.20.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.24.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.28.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.32.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.36.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.40.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.44.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.48.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","103.221.92.0/22","24","APNIC RPKI Root","2020-08-18T05:03:24Z","2021-04-29T06:55:15Z","3169"
> "24373","2406:1e80::/48","64","APNIC RPKI Root","2020-06-03T03:23:48Z","2021-04-29T06:55:15Z","2773"
> "398704","103.98.164.0/22","24","APNIC RPKI Root","2020-09-22T02:10:10Z","2021-04-29T06:55:15Z","3333"
> "4812","103.24.116.0/24","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2743"
> "4812","103.24.118.0/23","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2743"
> "4812","103.5.192.0/22","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2743"
> "4812","150.242.238.0/23","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2743"
> "4812","202.89.96.0/24","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2743"
> "4812","43.254.152.0/24","24","APNIC RPKI Root","2020-05-29T01:14:42Z","2021-04-29T06:55:15Z","2743"
> "59033","2402:1440::/32","48","APNIC RPKI Root","2020-10-13T14:06:38Z","2021-04-29T06:55:15Z","1241"
> "59083","103.10.0.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.10.0.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.10.1.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.10.2.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.10.2.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.10.3.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.198.220.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.221.16.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.221.20.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.221.24.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.221.28.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.24.116.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.24.116.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.24.116.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.24.117.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.24.118.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.24.118.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.24.119.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.7.140.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.7.140.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","103.7.142.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","150.242.236.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.136.248.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.136.248.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.136.249.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.136.250.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.136.250.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.140.140.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.140.140.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.140.142.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.174.124.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.89.108.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.89.108.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","202.89.110.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","203.90.12.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","2403:1b80::/48","48","APNIC RPKI Root","2020-05-09T03:43:11Z","2021-04-29T06:55:15Z","2422"
> "59083","43.254.153.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","43.254.154.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","43.254.155.0/24","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","59.153.164.0/22","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59083","59.153.168.0/23","24","APNIC RPKI Root","2020-07-13T10:42:23Z","2021-04-29T06:55:15Z","2984"
> "59803","2403:1b80::/32","64","APNIC RPKI Root","2020-06-03T03:28:53Z","2021-04-29T06:55:15Z","2777"
> "59803","2403:1b80::/48","64","APNIC RPKI Root","2020-06-03T03:28:53Z","2021-04-29T06:55:15Z","2777"
> "59803","2406:1e80::/32","64","APNIC RPKI Root","2020-06-03T03:28:53Z","2021-04-29T06:55:15Z","2777"
> "63689","2402:1440::/32","48","APNIC RPKI Root","2020-10-13T14:06:21Z","2021-04-29T06:55:15Z","1239"
