### PR TITLE
Updated manifest entry filename validation

### DIFF
--- a/rpki-parent/pom.xml
+++ b/rpki-parent/pom.xml
@@ -18,7 +18,7 @@
 
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
-        <rpki-commons.version>1.16</rpki-commons.version>
+        <rpki-commons.version>1.17-SNAPSHOT</rpki-commons.version>
 
         <!-- Micrometer.version from spring boot -->
 

--- a/rpki-parent/pom.xml
+++ b/rpki-parent/pom.xml
@@ -18,7 +18,7 @@
 
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
-        <rpki-commons.version>1.17-SNAPSHOT</rpki-commons.version>
+        <rpki-commons.version>1.17</rpki-commons.version>
 
         <!-- Micrometer.version from spring boot -->
 

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/ta/TrustAnchorsFactory.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/ta/TrustAnchorsFactory.java
@@ -198,8 +198,8 @@ public class TrustAnchorsFactory {
 
                 final RpkiObject certObject = new RpkiObject(childCertificate);
                 rpkiObjects.put(tx, certObject);
-                rpkiObjects.addLocation(tx, certObject.key(), ca.repositoryURI + child.dn + ".cer");
-                manifestBuilder.addFile(child.dn + ".cer", childCertificate.getEncoded());
+                rpkiObjects.addLocation(tx, certObject.key(), child.certificateLocation);
+                manifestBuilder.addFile(child.certificateLocation.substring(child.certificateLocation.lastIndexOf('/') + 1), childCertificate.getEncoded());
             }
         }
 

--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationServiceTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationServiceTest.java
@@ -215,7 +215,7 @@ public class CertificateTreeValidationServiceTest extends GenericStorageTest {
             TrustAnchorsFactory.CertificateAuthority child = TrustAnchorsFactory.CertificateAuthority.builder()
                 .dn("CN=child-ca")
                 .keyPair(childKeyPair)
-                .certificateLocation(TA_CA_REPOSITORY_URI + "CN=child-ca.cer")
+                .certificateLocation(TA_CA_REPOSITORY_URI + "child-ca.cer")
                 .resources(IpResourceSet.parse("192.168.128.0/17"))
                 .notifyURI(TA_RRDP_NOTIFY_URI)
                 .manifestURI("rsync://rpki.test/CN=child-ca/child-ca.mft")


### PR DESCRIPTION
Using rpki-commons 1.17-SNAPSHOT from the https://github.com/RIPE-NCC/rpki-commons/pull/35 PR.

Fixes test cases related to stricter manifest entry filename validation.