### PR TITLE
Only fail the entire manifest when entry hashes do not match

### DIFF
--- a/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationServiceTest.java
+++ b/rpki-validator/src/test/java/net/ripe/rpki/validator3/domain/validation/CertificateTreeValidationServiceTest.java
@@ -400,8 +400,7 @@ public class CertificateTreeValidationServiceTest extends GenericStorageTest {
     }
 
     @Test
-    public void should_reject_complete_manifest_when_single_object_fails_validation_with_strict_validation(){
-
+    public void should_accept_validated_objects_from_manifest_even_when_single_object_fails_validation_with_strict_validation(){
         TrustAnchor ta = wtx(tx -> {
             TrustAnchor ta1 = factory.createTrustAnchor(tx, x -> x.roaPrefixes(Lists.newArrayList(
                     RoaPrefix.of(IpRange.prefix(IpAddress.parse("192.168.0.0"), 24), 24, Asn.parse("64512"),
@@ -434,6 +433,6 @@ public class CertificateTreeValidationServiceTest extends GenericStorageTest {
 
         List<Pair<CertificateTreeValidationRun, RpkiObject>> validatedRoas = rtx(tx -> this.getValidationRuns()
                 .findCurrentlyValidated(tx, RpkiObject.Type.ROA).collect(toList()));
-        assertThat(validatedRoas).hasSize(0);
+        assertThat(validatedRoas).hasSize(1);
     }
 }


### PR DESCRIPTION
If included objects fail validation, only drop the failed objects, not
all objects on the manifest. The main intent is to prevent MITM
attacks where an attacker replaces or removes objects from the
publication point. Checking that all manifest entries are present and
the hashes match prevents this.

Bugs in the CA or publication server that cause invalid objects to be
published (with the correct hash on the manifest) will not be
prevented and will not cause all objects to become invalid.