### PR TITLE
Relax update intervals

### DIFF
--- a/rpki-validator/Changelog.txt
+++ b/rpki-validator/Changelog.txt
@@ -1,4 +1,4 @@
-* TBD Ties de Kock <tdekock@ripe.net> - 3.2
+* Mon Dec 21 2020 Ties de Kock <tdekock@ripe.net> - 3.2
 
 - Change the default value for the cleanup of repositories that have not been
   referenced in a validation run to two days.

--- a/rpki-validator/Changelog.txt
+++ b/rpki-validator/Changelog.txt
@@ -1,3 +1,10 @@
+* TBD Ties de Kock <tdekock@ripe.net> - 3.2
+
+- Change the default value for the cleanup of repositories that have not been
+  referenced in a validation run to two days.
+- Change the default interval at which RRDP repositories are checked for
+  updated to 10  minutes.
+
 * Tue Dec  9 2020 Erik Rozendaal <erozendaal@ripe.net> - 3.2
 
 - only fail full manifest when entries not found or hashes don't

--- a/rpki-validator/src/main/resources/packaging/generic/conf/application-defaults.properties
+++ b/rpki-validator/src/main/resources/packaging/generic/conf/application-defaults.properties
@@ -77,12 +77,16 @@ rpki.validator.bgp.ris.visibility.threshold=10
 # (https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html#parse-java.lang.CharSequence-).
 # The default value is 10 minutes.
 rpki.validator.rsync.repository.download.interval=PT10M
-rpki.validator.rrdp.repository.download.interval=PT2M
+rpki.validator.rrdp.repository.download.interval=PT10M
 
 rpki.validator.rrdp.trust.all.tls.certificates=false
 
 rpki.validator.rpki.object.cleanup.grace.duration=P7D
-rpki.validator.rpki.repository.cleanup.grace.duration=P7D
+#
+# Duration before repositories that have not been referenced
+# from a validation run are cleaned up.
+#
+rpki.validator.rpki.repository.cleanup.grace.duration=P2D
 
 rpki.validator.validation.run.cleanup.grace.duration=PT6H
 


### PR DESCRIPTION
  * Faster removal of repositories not referenced by a validation run: 2
    days.
  * Increase default RRDP update interval to ten minutes.

Addresses/Fixes #307.

@erikrozendaal can you double check that this is safe? I am uncertain about the behaviour in the setting where a parent and child repository update very infrequently (i.e. > two days)and do not need to be revalidated, which is the moment at which we update reachability.

For terminology:
```
+------------+
| Parent     |
| repository |
+------------+
      |
      |
      v
+------------+
| Child      |
| repository |
+------------+
```