### PR TITLE
Remove xstream as transitive dependency

### DIFF
--- a/rpki-parent/pom.xml
+++ b/rpki-parent/pom.xml
@@ -39,6 +39,12 @@
             <groupId>net.ripe.rpki</groupId>
             <artifactId>rpki-commons</artifactId>
             <version>${rpki-commons.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/rpki-validator/Changelog.txt
+++ b/rpki-validator/Changelog.txt
@@ -5,6 +5,7 @@ continue until the 1st of July 2021
 
 - Spring Boot 2.4.4
 - Updated the banner and README.md
+- Excluded xstream as a dependency (unused)
 - fix: Updated default settings to cleanup every 2 days on non-CentOS
 
 * Tue Mar 2 2021 Ties de Kock <tdekock@ripe.net> - 3.2


### PR DESCRIPTION
As a software engineer I want to exclude xstream from the transitive dependencies so I do not get spurious alerts about vulnerabilities in a unused transitive dependency.