### PR TITLE
Update LACNIC and APNIC tal to use HTTPS

### DIFF
--- a/rpki-validator/src/main/resources/packaging/generic/workdirs/preconfigured-tals/apnic.tal
+++ b/rpki-validator/src/main/resources/packaging/generic/workdirs/preconfigured-tals/apnic.tal
@@ -1,4 +1,4 @@
 ca.name = APNIC RPKI Root
-certificate.location = https://tal.apnic.net/apnic.cer,rsync://rpki.apnic.net/repository/apnic-rpki-root-iana-origin.cer
+certificate.location = https://rpki.apnic.net/repository/apnic-rpki-root-iana-origin.cer,rsync://rpki.apnic.net/repository/apnic-rpki-root-iana-origin.cer
 public.key.info = MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAx9RWSL61YAAYumEiU8z8qH2ETVIL01ilxZlzIL9JYSORMN5Cmtf8V2JblIealSqgOTGjvSjEsiV73s67zYQI7C/iSOb96uf3/s86NqbxDiFQGN8qG7RNcdgVuUlAidl8WxvLNI8VhqbAB5uSg/MrLeSOvXRja041VptAxIhcGzDMvlAJRwkrYK/Mo8P4E2rSQgwqCgae0ebY1CsJ3Cjfi67C1nw7oXqJJovvXJ4apGmEv8az23OLC6Ki54Ul/E6xk227BFttqFV3YMtKx42HcCcDVZZy01n7JjzvO8ccaXmHIgR7utnqhBRNNq5Xc5ZhbkrUsNtiJmrZzVlgU6Ou0wIDAQAB
 prefetch.uris = rsync://rpki.apnic.net/member_repository/

--- a/rpki-validator/src/main/resources/packaging/generic/workdirs/preconfigured-tals/lacnic.tal
+++ b/rpki-validator/src/main/resources/packaging/generic/workdirs/preconfigured-tals/lacnic.tal
@@ -1,4 +1,4 @@
 ca.name = LACNIC RPKI Root
-certificate.location = rsync://repository.lacnic.net/rpki/lacnic/rta-lacnic-rpki.cer
+certificate.location = https://rrdp.lacnic.net/ta/rta-lacnic-rpki.cer,rsync://repository.lacnic.net/rpki/lacnic/rta-lacnic-rpki.cer
 public.key.info = MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqZEzhYK0+PtDOPfub/KRc3MeWx3neXx4/wbnJWGbNAtbYqXg3uU5J4HFzPgk/VIppgSKAhlO0H60DRP48by9gr5/yDHu2KXhOmnMg46sYsUIpfgtBS9+VtrqWziJfb+pkGtuOWeTnj6zBmBNZKK+5AlMCW1WPhrylIcB+XSZx8tk9GS/3SMQ+YfMVwwAyYjsex14Uzto4GjONALE5oh1M3+glRQduD6vzSwOD+WahMbc9vCOTED+2McLHRKgNaQf0YJ9a1jG9oJIvDkKXEqdfqDRktwyoD74cV57bW3tBAexB7GglITbInyQAsmdngtfg2LUMrcROHHP86QPZINjDQIDAQAB
 prefetch.uris = rsync://repository.lacnic.net/rpki/


### PR DESCRIPTION
lacnic tal from https://www.lacnic.net/4984/2/lacnic/rpki-rpki-trust-anchor